### PR TITLE
Add graphical hexagonal board representation using HTML and CSS

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,4 +24,6 @@ jobs:
     - name: Install
       run: yarn
     - name: Test
-      run: npm test
+      run: |
+        yarn test
+        yarn test:e2e

--- a/gameStateFile.json
+++ b/gameStateFile.json
@@ -15,7 +15,7 @@
       "value": null
     },
     {
-      "value": null
+      "value": 2
     },
     {
       "value": null

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,83 @@
+/* Great source: https://css-tricks.com/hexagons-and-beyond-flexible-responsive-grid-patterns-sans-media-queries/ */
+
+#board {
+    display: grid;
+    place-self: center;
+    justify-content: center;
+    margin: 20px;
+    padding: 20px;
+    background: #333;
+}
+
+.main {
+    display: flex;
+    flex-direction: column;
+    /* size  */
+    --s: 30px;
+    /* margin */
+    --m: 3px;
+    /* height equivalent to 2 overlapping hexagons, used to move every second row */
+    --f: calc(1.732 * var(--s) + 4 * var(--m) - 1px);
+}
+
+.container {
+    /*disable white space between inline block element */
+    font-size: 0;
+    width: calc((var(--nr) + (var(--nr)) / 2)*(var(--s) + 2*var(--m)));
+    padding-bottom: calc(var(--s) * 0.2885 * 2);
+    padding-top: calc(var(--s) * 0.2885 * 2);
+}
+
+.container div {
+    width: var(--s);
+    margin: var(--m);
+    height: calc(var(--s)*1.1547);
+    display: inline-block;
+    font-size: initial;
+    clip-path: polygon(0% 25%, 0% 75%, 50% 100%, 100% 75%, 100% 25%, 50% 0%);
+    margin-bottom: calc(var(--m) - var(--s)*0.2885);
+}
+
+.container::before,
+.container i {
+    content: "";
+    width: calc((var(--s) + 2*var(--m))*((var(--nr))/2));
+    float: left;
+    height: calc((var(--f)*(var(--nr))/2) + var(--s)*0.2885);
+    shape-outside: linear-gradient(to top right, #000 50%, #0000 0);
+}
+
+.container i {
+    float: right;
+    shape-outside: linear-gradient(to bottom left, #000 calc(50% - 1*var(--s)), #0000 0);
+}
+
+#top-edge, #bottom-edge, #left-edge, #right-edge {
+    position: absolute;
+    width: calc((var(--s) + 2*var(--m))*(var(--nr)));
+    height: calc(var(--s)*0.2885*2);
+    background: white;
+    clip-path: polygon(2% 0%, 98% 0%, 100% 50%, 98% 100%, 2% 100%, 0% 50%);
+}
+
+#top-edge {
+    transform: translate(calc(var(--s) / 2), calc(0px - 2*var(--m)));
+}
+
+#bottom-edge {
+    transform: translate(calc((var(--s) + 2*var(--m))*((var(--nr) - 1)/2) + var(--s) / 1.5), calc(var(--f)*var(--nr)/2 + var(--s)/1.5 + var(--s) * 0.2885 * 2)) rotate(180deg);
+}
+
+#left-edge, #right-edge {
+    background: black;
+    transform-origin: left;
+}
+
+#left-edge {
+    transform: scaleY(-1) rotate(300deg) translate(calc(0px - 2*var(--m) + var(--s) / 2), calc(0px - var(--s)*0.2885*2.5));
+}
+
+#right-edge {
+    transform-origin: right;
+    transform: scaleY(-1) rotate(120deg) translate(calc(0px - 2*var(--m) - var(--s) / 1.5), calc(0px + var(--s)*0.2885*2 - var(--s) / 0.9));
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -11,22 +11,23 @@
 
 .hex-board-frame {
     display: flex;
-    flex-direction: column;
     /* width of one hexagon  */
     --hexwidth: 30px;
     /* margin around hexagons */
     --hexmargin: 3px;
     /* condensed height equivalent to the height of 2 overlapping hexagons (used to move every second row) */
     --hexcondheight: calc(1.732 * var(--hexwidth) + 4 * var(--hexmargin) - 1px);
+    /* additional height of one hexagon compared to its width (to have nice round hexagons)  */
+    --hexaddheight: calc(var(--hexwidth) * 0.2885);
     /* last variable `--rows` holds the number of rows and is injected by the template */
 }
 
 .hex-board-container {
     /*disable white space between inline block element */
     font-size: 0;
-    width: calc((var(--rows) + (var(--rows)) / 2)*(var(--hexwidth) + 2*var(--hexmargin)));
-    padding-bottom: calc(var(--hexwidth) * 0.2885 * 2);
-    padding-top: calc(var(--hexwidth) * 0.2885 * 2);
+    width: calc((var(--rows) * 1.5)*(var(--hexwidth) + 2*var(--hexmargin)));
+    padding-bottom: calc(var(--hexaddheight) * 2);
+    padding-top: calc(var(--hexaddheight) * 2);
 }
 
 .hex-board-container div {
@@ -34,9 +35,8 @@
     margin: var(--hexmargin);
     height: calc(var(--hexwidth)*1.1547);
     display: inline-block;
-    font-size: initial;
     clip-path: polygon(0% 25%, 0% 75%, 50% 100%, 100% 75%, 100% 25%, 50% 0%);
-    margin-bottom: calc(var(--hexmargin) - var(--hexwidth)*0.2885);
+    margin-bottom: calc(var(--hexmargin) - var(--hexaddheight));
 }
 
 .hex-board-container::before,
@@ -44,7 +44,7 @@
     content: "";
     width: calc((var(--hexwidth) + 2*var(--hexmargin))*((var(--rows))/2));
     float: left;
-    height: calc((var(--hexcondheight)*(var(--rows))/2) + var(--hexwidth)*0.2885);
+    height: calc((var(--hexcondheight)*(var(--rows))/2) + var(--hexaddheight));
     shape-outside: linear-gradient(to top right, #000 50%, #0000 0);
 }
 
@@ -56,27 +56,28 @@
 .top-edge, .bottom-edge, .left-edge, .right-edge {
     position: absolute;
     width: calc((var(--hexwidth) + 2*var(--hexmargin))*(var(--rows)));
-    height: calc(var(--hexwidth)*0.2885*2);
-    background: white;
+    height: calc(var(--hexaddheight)*2);
     clip-path: polygon(2% 0%, 98% 0%, 100% 50%, 98% 100%, 2% 100%, 0% 50%);
 }
 
 .top-edge {
+    background: white;
     transform: translate(calc(var(--hexwidth) / 2), calc(0px - 2*var(--hexmargin)));
 }
 
 .bottom-edge {
-    transform: translate(calc((var(--hexwidth) + 2*var(--hexmargin))*((var(--rows) - 1)/2) + var(--hexwidth) / 1.5), calc(var(--hexcondheight)*var(--rows)/2 + var(--hexwidth)/1.5 + var(--hexwidth) * 0.2885 * 2)) rotate(180deg);
+    background: white;
+    transform: translate(calc((var(--hexwidth) + 2*var(--hexmargin))*((var(--rows) - 1)/2) + var(--hexwidth) / 1.5), calc(var(--hexcondheight)*var(--rows)/2 + var(--hexwidth)/1.5 + var(--hexaddheight) * 2));
 }
 
 .left-edge {
     background: black;
     transform-origin: left;
-    transform: scaleY(-1) rotate(300deg) translate(calc(0px - 2*var(--hexmargin) + var(--hexwidth) / 2), calc(0px - var(--hexwidth)*0.2885*2.5));
+    transform: rotate(60deg) translate(calc(0px - 2*var(--hexmargin) + var(--hexwidth) / 2), calc(var(--hexaddheight)*2.5));
 }
 
 .right-edge {
     background: black;
     transform-origin: right;
-    transform: scaleY(-1) rotate(120deg) translate(calc(0px - 2*var(--hexmargin) - var(--hexwidth) / 1.5), calc(0px + var(--hexwidth)*0.2885*2 - var(--hexwidth) / 0.9));
+    transform: rotate(240deg) translate(calc(0px - 2*var(--hexmargin) - var(--hexwidth) / 1.5), calc(0px - var(--hexaddheight)*2 + var(--hexwidth) / 0.9));
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,6 +1,6 @@
 /* Great source: https://css-tricks.com/hexagons-and-beyond-flexible-responsive-grid-patterns-sans-media-queries/ */
 
-#board {
+.gameboard {
     display: grid;
     place-self: center;
     justify-content: center;
@@ -9,75 +9,74 @@
     background: #333;
 }
 
-.main {
+.hex-board-frame {
     display: flex;
     flex-direction: column;
-    /* size  */
-    --s: 30px;
-    /* margin */
-    --m: 3px;
-    /* height equivalent to 2 overlapping hexagons, used to move every second row */
-    --f: calc(1.732 * var(--s) + 4 * var(--m) - 1px);
+    /* width of one hexagon  */
+    --hexwidth: 30px;
+    /* margin around hexagons */
+    --hexmargin: 3px;
+    /* condensed height equivalent to the height of 2 overlapping hexagons (used to move every second row) */
+    --hexcondheight: calc(1.732 * var(--hexwidth) + 4 * var(--hexmargin) - 1px);
+    /* last variable `--rows` holds the number of rows and is injected by the template */
 }
 
-.container {
+.hex-board-container {
     /*disable white space between inline block element */
     font-size: 0;
-    width: calc((var(--nr) + (var(--nr)) / 2)*(var(--s) + 2*var(--m)));
-    padding-bottom: calc(var(--s) * 0.2885 * 2);
-    padding-top: calc(var(--s) * 0.2885 * 2);
+    width: calc((var(--rows) + (var(--rows)) / 2)*(var(--hexwidth) + 2*var(--hexmargin)));
+    padding-bottom: calc(var(--hexwidth) * 0.2885 * 2);
+    padding-top: calc(var(--hexwidth) * 0.2885 * 2);
 }
 
-.container div {
-    width: var(--s);
-    margin: var(--m);
-    height: calc(var(--s)*1.1547);
+.hex-board-container div {
+    width: var(--hexwidth);
+    margin: var(--hexmargin);
+    height: calc(var(--hexwidth)*1.1547);
     display: inline-block;
     font-size: initial;
     clip-path: polygon(0% 25%, 0% 75%, 50% 100%, 100% 75%, 100% 25%, 50% 0%);
-    margin-bottom: calc(var(--m) - var(--s)*0.2885);
+    margin-bottom: calc(var(--hexmargin) - var(--hexwidth)*0.2885);
 }
 
-.container::before,
-.container i {
+.hex-board-container::before,
+.hex-board-container i {
     content: "";
-    width: calc((var(--s) + 2*var(--m))*((var(--nr))/2));
+    width: calc((var(--hexwidth) + 2*var(--hexmargin))*((var(--rows))/2));
     float: left;
-    height: calc((var(--f)*(var(--nr))/2) + var(--s)*0.2885);
+    height: calc((var(--hexcondheight)*(var(--rows))/2) + var(--hexwidth)*0.2885);
     shape-outside: linear-gradient(to top right, #000 50%, #0000 0);
 }
 
-.container i {
+.hex-board-container i {
     float: right;
-    shape-outside: linear-gradient(to bottom left, #000 calc(50% - 1*var(--s)), #0000 0);
+    shape-outside: linear-gradient(to bottom left, #000 calc(50% - 1*var(--hexwidth)), #0000 0);
 }
 
-#top-edge, #bottom-edge, #left-edge, #right-edge {
+.top-edge, .bottom-edge, .left-edge, .right-edge {
     position: absolute;
-    width: calc((var(--s) + 2*var(--m))*(var(--nr)));
-    height: calc(var(--s)*0.2885*2);
+    width: calc((var(--hexwidth) + 2*var(--hexmargin))*(var(--rows)));
+    height: calc(var(--hexwidth)*0.2885*2);
     background: white;
     clip-path: polygon(2% 0%, 98% 0%, 100% 50%, 98% 100%, 2% 100%, 0% 50%);
 }
 
-#top-edge {
-    transform: translate(calc(var(--s) / 2), calc(0px - 2*var(--m)));
+.top-edge {
+    transform: translate(calc(var(--hexwidth) / 2), calc(0px - 2*var(--hexmargin)));
 }
 
-#bottom-edge {
-    transform: translate(calc((var(--s) + 2*var(--m))*((var(--nr) - 1)/2) + var(--s) / 1.5), calc(var(--f)*var(--nr)/2 + var(--s)/1.5 + var(--s) * 0.2885 * 2)) rotate(180deg);
+.bottom-edge {
+    transform: translate(calc((var(--hexwidth) + 2*var(--hexmargin))*((var(--rows) - 1)/2) + var(--hexwidth) / 1.5), calc(var(--hexcondheight)*var(--rows)/2 + var(--hexwidth)/1.5 + var(--hexwidth) * 0.2885 * 2)) rotate(180deg);
 }
 
-#left-edge, #right-edge {
+.left-edge {
     background: black;
     transform-origin: left;
+    transform: scaleY(-1) rotate(300deg) translate(calc(0px - 2*var(--hexmargin) + var(--hexwidth) / 2), calc(0px - var(--hexwidth)*0.2885*2.5));
 }
 
-#left-edge {
-    transform: scaleY(-1) rotate(300deg) translate(calc(0px - 2*var(--m) + var(--s) / 2), calc(0px - var(--s)*0.2885*2.5));
-}
-
-#right-edge {
+.right-edge {
+    background: black;
     transform-origin: right;
-    transform: scaleY(-1) rotate(120deg) translate(calc(0px - 2*var(--m) - var(--s) / 1.5), calc(0px + var(--s)*0.2885*2 - var(--s) / 0.9));
+    transform: scaleY(-1) rotate(120deg) translate(calc(0px - 2*var(--hexmargin) - var(--hexwidth) / 1.5), calc(0px + var(--hexwidth)*0.2885*2 - var(--hexwidth) / 0.9));
 }

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -20,7 +20,7 @@ describe('AppController', () => {
       expect(appController.getBoardStateFromFile().gameState).toEqual(
         parseGameStateFromMultilineString(`
 ⬢ ⬡ ⬢
- ⬡ ⬡ ⬡
+ ⬡ W ⬡
   ⬡ ⬡ ⬡
 `),
       );

--- a/src/handlebars/helpers.ts
+++ b/src/handlebars/helpers.ts
@@ -1,0 +1,10 @@
+import { handlebars } from 'hbs';
+
+export function registerHandlebarsHelpers() {
+    handlebars.registerHelper('ifCond', function (v1, v2, options) {
+        if (v1 === v2) {
+            return options.fn(this);
+        }
+        return options.inverse(this);
+    });
+}

--- a/src/handlebars/helpers.ts
+++ b/src/handlebars/helpers.ts
@@ -8,3 +8,7 @@ export function registerHandlebarsHelpers() {
         return options.inverse(this);
     });
 }
+
+export function unregisterHandlebarsHelpers() {
+    handlebars.unregisterHelper('ifCond');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,13 +2,24 @@ import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { join } from 'path';
+import * as hbs from 'hbs';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
   app.useStaticAssets(join(__dirname, '..', 'public'));
   app.setBaseViewsDir(join(__dirname, '..', 'views'));
+  registerHandlebarsHelpers();
   app.setViewEngine('hbs');
   await app.listen(3000);
+}
+
+function registerHandlebarsHelpers() {
+  hbs.handlebars.registerHelper('ifCond', function (v1, v2, options) {
+    if (v1 === v2) {
+      return options.fn(this);
+    }
+    return options.inverse(this);
+  });
 }
 
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { join } from 'path';
-import { handlebars } from 'hbs';
+import { registerHandlebarsHelpers } from './handlebars/helpers';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -11,15 +11,6 @@ async function bootstrap() {
   registerHandlebarsHelpers();
   app.setViewEngine('hbs');
   await app.listen(3000);
-}
-
-export function registerHandlebarsHelpers() {
-  handlebars.registerHelper('ifCond', function (v1, v2, options) {
-    if (v1 === v2) {
-      return options.fn(this);
-    }
-    return options.inverse(this);
-  });
 }
 
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { join } from 'path';
-import * as hbs from 'hbs';
+import { handlebars } from 'hbs';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -13,8 +13,8 @@ async function bootstrap() {
   await app.listen(3000);
 }
 
-function registerHandlebarsHelpers() {
-  hbs.handlebars.registerHelper('ifCond', function (v1, v2, options) {
+export function registerHandlebarsHelpers() {
+  handlebars.registerHelper('ifCond', function (v1, v2, options) {
     if (v1 === v2) {
       return options.fn(this);
     }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,17 +1,37 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import request from 'supertest';
 import { AppModule } from './../src/app.module';
+import { join } from 'path';
+import { registerHandlebarsHelpers, unregisterHandlebarsHelpers } from '../src/handlebars/helpers';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication;
+  let app: NestExpressApplication;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useStaticAssets(join(__dirname, '..', 'public'));
+    app.setBaseViewsDir(join(__dirname, '..', 'views'));
+    registerHandlebarsHelpers();
+    app.setViewEngine('hbs');
     await app.init();
+  });
+
+  afterAll(async () => {
+    unregisterHandlebarsHelpers();
+    await app.close();
+  });
+
+  it(`/GET (root) should render the board as stored in the config file`, () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect(/<div style="background: #eea">/)
+      .expect(/<div style="background: black">/)
+      .expect(/<div style="background: white">/);
   });
 });

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -8,22 +8,22 @@
 </head>
 
 <body>
-  <div id="board">
-    <div class="main" style="--nr: {{gameState.board.length}}">
-      <div id="left-edge"></div>
-      <div id="right-edge"></div>
-      <div id="top-edge"></div>
-      <div id="bottom-edge"></div>
-      <div class="container">
+  <div class="gameboard">
+    <div class="hex-board-frame" style="--rows: {{gameState.board.length}}">
+      <div class="left-edge"></div>
+      <div class="right-edge"></div>
+      <div class="top-edge"></div>
+      <div class="bottom-edge"></div>
+      <div class="hex-board-container">
         <i></i>
         {{#each gameState.board}}
-        {{#each this}}
-        <div style="background: {{#ifCond this.value 'empty'}}#eea{{else}}{{this.value}}{{/ifCond}}">
-        </div>
+          {{#each this}}
+            <div style="background: {{#ifCond this.value 'empty'}}#eea{{else}}{{this.value}}{{/ifCond}}">
+            </div>
+          {{/each}}
         {{/each}}
-        {{/each}}
-        </div>
       </div>
+    </div>
   </div>
 </body>
 

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -4,17 +4,26 @@
 <head>
   <meta charset="utf-8" />
   <title>Hex</title>
+  <link rel="stylesheet" type="text/css" href="css/style.css" />
 </head>
 
 <body>
   <div id="board">
-    {{#each gameState.board}}
-    <div style="margin-left:{{@index}}0px;">
-      {{#each this}}
-      <span>{{this.value}}</span>
-      {{/each}}
-    </div>
-    {{/each}}
+    <div class="main" style="--nr: {{gameState.board.length}}">
+      <div id="left-edge"></div>
+      <div id="right-edge"></div>
+      <div id="top-edge"></div>
+      <div id="bottom-edge"></div>
+      <div class="container">
+        <i></i>
+        {{#each gameState.board}}
+        {{#each this}}
+        <div style="background: {{#ifCond this.value 'empty'}}#eea{{else}}{{this.value}}{{/ifCond}}">
+        </div>
+        {{/each}}
+        {{/each}}
+        </div>
+      </div>
   </div>
 </body>
 


### PR DESCRIPTION
## Checklist

- [x] Add graphical hexagonal board representation using HTML and CSS
- [x] Add black and white edges
- [x] Replace hacky mapping of the value `"empty"` to `"#eea"` in Controller by a HBS Helper
- [x] Add E2E tests

## Demo

![hex-board-html-css](https://user-images.githubusercontent.com/14542336/154067217-9f59ad29-0f42-435f-805b-6d246e456c76.gif)

