### PR TITLE
Improve player's turn and win message

### DIFF
--- a/mobile-app/src/components/Board/Board.test.tsx
+++ b/mobile-app/src/components/Board/Board.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { GameState } from '../../../utils';
+import { Coordinates, GameState } from '../../../utils';
 import Board from './Board';
+import { Text } from 'react-native';
 
 describe('Board', () => {
   it('Does not throw any error', () => {
@@ -111,10 +112,25 @@ describe('Board', () => {
         ],
       ],
     };
+    const onCellPress = (coordinates: Coordinates) => {};
+    const getPlayersTurnElt = (gameState: GameState): JSX.Element => {
+      return <Text>Dummy Player's Turn Element</Text>;
+    };
+    const getWinMsgElt = (gameState: GameState): JSX.Element => {
+      return <Text>Dummy Win Message Element</Text>;
+    };
     expect(() =>
-      renderer.create(<Board gameState={gamestate} />),
+      renderer.create(
+        <Board
+          gameState={gamestate}
+          onCellPress={onCellPress}
+          getPlayersTurnElt={getPlayersTurnElt}
+          getWinMsgElt={getWinMsgElt}
+        />,
+      ),
     ).not.toThrowError();
   });
+
   it('Render a board with the correct nb of cells', () => {
     const gamestate: GameState = {
       turn: 'white',
@@ -141,8 +157,24 @@ describe('Board', () => {
         ],
       ],
     };
+    const onCellPress = (coordinates: Coordinates) => {};
+    const getPlayersTurnElt = (gameState: GameState): JSX.Element => {
+      return <Text>Dummy Player's Turn Element</Text>;
+    };
+    const getWinMsgElt = (gameState: GameState): JSX.Element => {
+      return <Text>Dummy Win Message Element</Text>;
+    };
 
-    const board = renderer.create(<Board gameState={gamestate} />).toJSON();
+    const board = renderer
+      .create(
+        <Board
+          gameState={gamestate}
+          onCellPress={onCellPress}
+          getPlayersTurnElt={getPlayersTurnElt}
+          getWinMsgElt={getWinMsgElt}
+        />,
+      )
+      .toJSON();
 
     expect(board.children[1].children[0].children.length).toBe(23);
   });

--- a/mobile-app/src/components/Board/Board.tsx
+++ b/mobile-app/src/components/Board/Board.tsx
@@ -26,7 +26,7 @@ export default function Board({
   const svgSize = getApproximateSvgSize(gameState.board.length);
   return gameState.winner ? (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      {getWinMsgElt(gameState)}
+      <View style={{ height: '100px' }}>{getWinMsgElt(gameState)}</View>
       <Svg width={svgSize} height={svgSize}>
         {generateBoardCells(gameState).map(
           ({ withoutBorderCoordinates, svgPointsToDraw, type }, index) =>
@@ -63,7 +63,7 @@ export default function Board({
     </View>
   ) : (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      {getPlayersTurnElt(gameState)}
+      <View style={{ height: '100px' }}>{getPlayersTurnElt(gameState)}</View>
       <Svg width={svgSize} height={svgSize}>
         {generateBoardCells(gameState).map(
           ({ withoutBorderCoordinates, svgPointsToDraw, type }, index) =>

--- a/mobile-app/src/components/Board/Board.tsx
+++ b/mobile-app/src/components/Board/Board.tsx
@@ -7,23 +7,26 @@ import {
   getApproximateSvgSize,
   generateBoardCells,
   CELL_STROKE_COLOR,
-  mapStoneColorToPlayerName,
 } from './boardService';
-import { updateGameState } from '../../services/localplayService';
 import { View, Text } from 'react-native';
 
 interface BoardProps {
   gameState: GameState;
   onCellPress: (coordinates: Coordinates) => void;
+  getPlayersTurnElt: (gameState: GameState) => JSX.Element;
+  getWinMsgElt: (gameState: GameState) => JSX.Element;
 }
 
-export default function Board({ gameState, onCellPress }: BoardProps) {
+export default function Board({
+  gameState,
+  onCellPress,
+  getPlayersTurnElt,
+  getWinMsgElt,
+}: BoardProps) {
   const svgSize = getApproximateSvgSize(gameState.board.length);
   return gameState.winner ? (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text style={{ fontSize: 32 }}>
-        Player {mapStoneColorToPlayerName(gameState.winner)} has won !
-      </Text>
+      {getWinMsgElt(gameState)}
       <Svg width={svgSize} height={svgSize}>
         {generateBoardCells(gameState).map(
           ({ withoutBorderCoordinates, svgPointsToDraw, type }, index) =>
@@ -60,9 +63,7 @@ export default function Board({ gameState, onCellPress }: BoardProps) {
     </View>
   ) : (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text style={{ fontSize: 32 }}>
-        {mapStoneColorToPlayerName(gameState.turn)}, it's your turn !
-      </Text>
+      {getPlayersTurnElt(gameState)}
       <Svg width={svgSize} height={svgSize}>
         {generateBoardCells(gameState).map(
           ({ withoutBorderCoordinates, svgPointsToDraw, type }, index) =>

--- a/mobile-app/src/components/Board/Board.tsx
+++ b/mobile-app/src/components/Board/Board.tsx
@@ -24,72 +24,78 @@ export default function Board({
   getWinMsgElt,
 }: BoardProps) {
   const svgSize = getApproximateSvgSize(gameState.board.length);
-  return gameState.winner ? (
+  return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <View style={{ height: '100px' }}>{getWinMsgElt(gameState)}</View>
-      <Svg width={svgSize} height={svgSize}>
-        {generateBoardCells(gameState).map(
-          ({ withoutBorderCoordinates, svgPointsToDraw, type }, index) =>
-            type === 'playable' ? (
-              <PlayableCell
-                key={index}
-                svgPoints={svgPointsToDraw}
-                strokeColor={CELL_STROKE_COLOR}
-                cellValue={
-                  gameState.board[withoutBorderCoordinates.y][
-                    withoutBorderCoordinates.x
-                  ]
-                }
-                onCellPress={() => {}}
-                isWinningCell={
-                  gameState.winningPath &&
-                  gameState.winningPath.some(
-                    (cell) =>
-                      cell.x == withoutBorderCoordinates.x &&
-                      cell.y == withoutBorderCoordinates.y,
-                  )
-                }
-              />
-            ) : (
-              <BorderCell
-                key={index}
-                svgPoints={svgPointsToDraw}
-                strokeColor={CELL_STROKE_COLOR}
-                playerBorder={type}
-              />
-            ),
-        )}
-      </Svg>
-    </View>
-  ) : (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <View style={{ height: '100px' }}>{getPlayersTurnElt(gameState)}</View>
-      <Svg width={svgSize} height={svgSize}>
-        {generateBoardCells(gameState).map(
-          ({ withoutBorderCoordinates, svgPointsToDraw, type }, index) =>
-            type === 'playable' ? (
-              <PlayableCell
-                key={index}
-                svgPoints={svgPointsToDraw}
-                strokeColor={CELL_STROKE_COLOR}
-                cellValue={
-                  gameState.board[withoutBorderCoordinates.y][
-                    withoutBorderCoordinates.x
-                  ]
-                }
-                onCellPress={() => onCellPress(withoutBorderCoordinates)}
-                isWinningCell={false}
-              />
-            ) : (
-              <BorderCell
-                key={index}
-                svgPoints={svgPointsToDraw}
-                strokeColor={CELL_STROKE_COLOR}
-                playerBorder={type}
-              />
-            ),
-        )}
-      </Svg>
+      {gameState.winner ? (
+        <>
+          <View style={{ height: '100px' }}>{getWinMsgElt(gameState)}</View>
+          <Svg width={svgSize} height={svgSize}>
+            {generateBoardCells(gameState).map(
+              ({ withoutBorderCoordinates, svgPointsToDraw, type }, index) =>
+                type === 'playable' ? (
+                  <PlayableCell
+                    key={index}
+                    svgPoints={svgPointsToDraw}
+                    strokeColor={CELL_STROKE_COLOR}
+                    cellValue={
+                      gameState.board[withoutBorderCoordinates.y][
+                        withoutBorderCoordinates.x
+                      ]
+                    }
+                    onCellPress={() => {}}
+                    isWinningCell={
+                      gameState.winningPath &&
+                      gameState.winningPath.some(
+                        (cell) =>
+                          cell.x == withoutBorderCoordinates.x &&
+                          cell.y == withoutBorderCoordinates.y,
+                      )
+                    }
+                  />
+                ) : (
+                  <BorderCell
+                    key={index}
+                    svgPoints={svgPointsToDraw}
+                    strokeColor={CELL_STROKE_COLOR}
+                    playerBorder={type}
+                  />
+                ),
+            )}
+          </Svg>
+        </>
+      ) : (
+        <>
+          <View style={{ height: '100px' }}>
+            {getPlayersTurnElt(gameState)}
+          </View>
+          <Svg width={svgSize} height={svgSize}>
+            {generateBoardCells(gameState).map(
+              ({ withoutBorderCoordinates, svgPointsToDraw, type }, index) =>
+                type === 'playable' ? (
+                  <PlayableCell
+                    key={index}
+                    svgPoints={svgPointsToDraw}
+                    strokeColor={CELL_STROKE_COLOR}
+                    cellValue={
+                      gameState.board[withoutBorderCoordinates.y][
+                        withoutBorderCoordinates.x
+                      ]
+                    }
+                    onCellPress={() => onCellPress(withoutBorderCoordinates)}
+                    isWinningCell={false}
+                  />
+                ) : (
+                  <BorderCell
+                    key={index}
+                    svgPoints={svgPointsToDraw}
+                    strokeColor={CELL_STROKE_COLOR}
+                    playerBorder={type}
+                  />
+                ),
+            )}
+          </Svg>
+        </>
+      )}
     </View>
   );
 }

--- a/mobile-app/src/screens/LocalScreen.tsx
+++ b/mobile-app/src/screens/LocalScreen.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, ScrollView } from 'react-native';
+import { View, ScrollView, Text } from 'react-native';
 import Board from '../components/Board/Board';
 import { Coordinates, GameState } from '../../utils';
 import type { LocalScreenProps } from './navigationTypes';
@@ -7,6 +7,7 @@ import {
   initNewGameState,
   updateGameState,
 } from '../services/localplayService';
+import { mapStoneColorToPlayerName } from '../components/Board/boardService';
 
 export function LocalScreen({ navigation }: LocalScreenProps) {
   const [gameState, setGameState] = React.useState<GameState | null>(null);
@@ -19,10 +20,33 @@ export function LocalScreen({ navigation }: LocalScreenProps) {
     updateGameState(gameState, coordinates).then(setGameState);
   };
 
+  const getPlayersTurnElt = (gameState: GameState): JSX.Element => {
+    return (
+      <Text style={{ fontSize: 32 }}>
+        {mapStoneColorToPlayerName(gameState.turn)}, it's your turn !
+      </Text>
+    );
+  };
+
+  const getWinMsgElt = (gameState: GameState): JSX.Element => {
+    return (
+      <Text style={{ fontSize: 32 }}>
+        Player {mapStoneColorToPlayerName(gameState.winner)} has won !
+      </Text>
+    );
+  };
+
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <ScrollView horizontal>
-        {gameState && <Board gameState={gameState} onCellPress={onCellPress} />}
+        {gameState && (
+          <Board
+            gameState={gameState}
+            onCellPress={onCellPress}
+            getPlayersTurnElt={getPlayersTurnElt}
+            getWinMsgElt={getWinMsgElt}
+          />
+        )}
       </ScrollView>
     </View>
   );

--- a/mobile-app/src/screens/RemoteScreen.tsx
+++ b/mobile-app/src/screens/RemoteScreen.tsx
@@ -34,23 +34,16 @@ export function RemoteScreen({ navigation, route }: RemoteScreenProps) {
       : () => {};
   };
 
-  const getPlayersTurnText = (
-    turn: StoneColor,
-    currentPlayerTurnToPlay: boolean,
-  ): String => {
-    if (currentPlayerTurnToPlay) {
-      return `${mapStoneColorToPlayerName(turn)}, it's your turn !`;
-    } else {
-      return `Wait for opponent's move...`;
-    }
-  };
-
   const getPlayersTurnElt = (state: GameState): JSX.Element => {
-    return (
-      <Text style={{ fontSize: 32 }}>
-        {getPlayersTurnText(state.turn, gameState.currentPlayerTurnToPlay)}
-      </Text>
-    );
+    if (gameState.currentPlayerTurnToPlay) {
+      return (
+        <Text style={{ fontSize: 32 }}>
+          {mapStoneColorToPlayerName(state.turn)}, it's your turn !
+        </Text>
+      );
+    } else {
+      return <Text style={{ fontSize: 24 }}>Wait for opponent's move...</Text>;
+    }
   };
 
   const getWinMsgElt = (state: GameState): JSX.Element => {

--- a/mobile-app/src/screens/RemoteScreen.tsx
+++ b/mobile-app/src/screens/RemoteScreen.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react';
 import { View, ScrollView, Text } from 'react-native';
 import Board from '../components/Board/Board';
-import { Coordinates, Game, GameAndStatus, GameState } from '../../utils';
+import {
+  Coordinates,
+  Game,
+  GameAndStatus,
+  GameState,
+  StoneColor,
+} from '../../utils';
 import type { RemoteScreenProps } from './navigationTypes';
 import { getGame, initNewGame, updateGame } from '../services/hexApiService';
+import { mapStoneColorToPlayerName } from '../components/Board/boardService';
 
 const REFRESH_TIMER = 1000;
 
@@ -27,6 +34,38 @@ export function RemoteScreen({ navigation, route }: RemoteScreenProps) {
       : () => {};
   };
 
+  const getPlayersTurnText = (
+    turn: StoneColor,
+    currentPlayerTurnToPlay: boolean,
+  ): String => {
+    if (currentPlayerTurnToPlay) {
+      return `${mapStoneColorToPlayerName(turn)}, it's your turn !`;
+    } else {
+      return `Wait for opponent's move...`;
+    }
+  };
+
+  const getPlayersTurnElt = (state: GameState): JSX.Element => {
+    return (
+      <Text style={{ fontSize: 32 }}>
+        {getPlayersTurnText(state.turn, gameState.currentPlayerTurnToPlay)}
+      </Text>
+    );
+  };
+
+  const getWinMsgElt = (state: GameState): JSX.Element => {
+    if (!gameState.currentPlayerTurnToPlay) {
+      return <Text style={{ fontSize: 32 }}>Congratulations, you won!</Text>;
+    } else {
+      return (
+        <React.Fragment>
+          <Text style={{ fontSize: 24 }}>You lost this game.</Text>
+          <Text style={{ fontSize: 24 }}>Better luck next time!</Text>
+        </React.Fragment>
+      );
+    }
+  };
+
   return gameState ? (
     gameState.readyToPlay ? (
       <View
@@ -38,7 +77,12 @@ export function RemoteScreen({ navigation, route }: RemoteScreenProps) {
         }}
       >
         <ScrollView horizontal>
-          <Board gameState={gameState.game.state} onCellPress={onCellPress} />
+          <Board
+            gameState={gameState.game.state}
+            onCellPress={onCellPress}
+            getPlayersTurnElt={getPlayersTurnElt}
+            getWinMsgElt={getWinMsgElt}
+          />
         </ScrollView>
       </View>
     ) : (


### PR DESCRIPTION
## Content

- [x] Edit message while in remote play to clarify if it's my turn to play or not
- [x] Improved win message to make it clearer if I won the game or lost it
- [x] Update automated tests
- [x] Use fixed height for messages to avoid screen blinking

Related to: https://trello.com/c/rUzI9XZe/69-05-improve-ui-for-current-player-in-distant-mode

## Demo

### Win
![hex-mobile-remote-win-fixed-height](https://user-images.githubusercontent.com/14542336/156140762-4b315187-d4d1-4bec-96ae-9fa19022cdb1.gif)

### Loose
![hex-mobile-remote-loose-fixed-height](https://user-images.githubusercontent.com/14542336/156140776-8d5bc77c-a5bf-4e11-b676-c668e1a2eb19.gif)

