### PR TITLE
API: add creation and update date to entities, and compute a game status

### DIFF
--- a/web-app/src/games/game.entity.ts
+++ b/web-app/src/games/game.entity.ts
@@ -4,6 +4,8 @@ import {
   PrimaryGeneratedColumn,
   JoinColumn,
   ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 import { GameState } from '../common/gameState';
 import { User } from '../users/user.entity';
@@ -23,4 +25,10 @@ export class Game {
 
   @Column('simple-json')
   state: GameState;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 }

--- a/web-app/src/games/games.service.spec.ts
+++ b/web-app/src/games/games.service.spec.ts
@@ -180,7 +180,6 @@ describe('GameService', () => {
 
   describe('getGameAndStatus', () => {
     it('should return "INITIALIZED" if there is only one player', () => {
-      // GIVEN
       const game = createGameEntityFromGameState(
         parseGameStateFromMultilineString(`
 ⬢ ⬡ ⬢
@@ -191,15 +190,12 @@ describe('GameService', () => {
       game.player1 = createUser(1, 'player1');
       const playerName = 'white';
 
-      // WHEN
       const gameAndStatus = gameService.getGameAndStatus(game, playerName);
 
-      // THEN
       expect(gameAndStatus.status).toEqual('INITIALIZED');
     });
 
     it('should return "RUNNING" if there are two players and the game is not won', () => {
-      // GIVEN
       const game = createGameEntityFromGameState(
         parseGameStateFromMultilineString(`
 ⬢ ⬡ ⬢
@@ -211,15 +207,12 @@ describe('GameService', () => {
       game.player2 = createUser(2, 'player2');
       const playerName = 'white';
 
-      // WHEN
       const gameAndStatus = gameService.getGameAndStatus(game, playerName);
 
-      // THEN
       expect(gameAndStatus.status).toEqual('RUNNING');
     });
 
     it('should return "ENDED" if the game is won', () => {
-      // GIVEN
       const game = createGameEntityFromGameState(
         parseGameStateFromMultilineString(`
 ⬢ ⬡ ⬢
@@ -232,10 +225,8 @@ describe('GameService', () => {
       game.state.winner = 'black';
       const playerName = 'white';
 
-      // WHEN
       const gameAndStatus = gameService.getGameAndStatus(game, playerName);
 
-      // THEN
       expect(gameAndStatus.status).toEqual('ENDED');
     });
   });

--- a/web-app/src/games/games.service.spec.ts
+++ b/web-app/src/games/games.service.spec.ts
@@ -44,6 +44,8 @@ function createGameEntityFromGameState(gameState: GameState): Game {
     player1: null,
     player2: null,
     state: gameState,
+    createdAt: null,
+    updatedAt: null,
   };
 }
 
@@ -51,6 +53,17 @@ function parseGameFromMultilineString(gameState: string): Game {
   return createGameEntityFromGameState(
     parseGameStateFromMultilineString(gameState),
   );
+}
+
+function createUser(userId: number, username: string): User {
+  return {
+    id: userId,
+    username,
+    password: '',
+    lastSessionId: '',
+    createdAt: undefined,
+    updatedAt: undefined,
+  };
 }
 
 describe('GameService', () => {
@@ -163,5 +176,72 @@ describe('GameService', () => {
           ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
 `).board,
     );
+  });
+
+  describe('getGameAndStatus', () => {
+    it('should return "INITIALIZED" if there is only one player', () => {
+      // GIVEN
+      const game = createGameEntityFromGameState(
+        parseGameStateFromMultilineString(`
+⬢ ⬡ ⬢
+ ⬡ W ⬡
+  ⬡ ⬡ ⬡
+       `),
+      );
+      const player1 = createUser(1, 'player1');
+      game.player1 = player1;
+      const playerName = 'white';
+
+      // WHEN
+      const gameAndStatus = gameService.getGameAndStatus(game, playerName);
+
+      // THEN
+      expect(gameAndStatus.status).toEqual('INITIALIZED');
+    });
+
+    it('should return "RUNNING" if there are two players and the game is not won', () => {
+      // GIVEN
+      const game = createGameEntityFromGameState(
+        parseGameStateFromMultilineString(`
+⬢ ⬡ ⬢
+ ⬡ W ⬡
+  ⬡ ⬡ ⬡
+       `),
+      );
+      const player1 = createUser(1, 'player1');
+      const player2 = createUser(2, 'player2');
+      game.player1 = player1;
+      game.player2 = player2;
+      const playerName = 'white';
+
+      // WHEN
+      const gameAndStatus = gameService.getGameAndStatus(game, playerName);
+
+      // THEN
+      expect(gameAndStatus.status).toEqual('RUNNING');
+    });
+
+    it('should return "ENDED" if the game is won', () => {
+      // GIVEN
+      const game = createGameEntityFromGameState(
+        parseGameStateFromMultilineString(`
+⬢ ⬡ ⬢
+ ⬡ W ⬡
+  ⬡ ⬡ ⬡
+       `),
+      );
+      const player1 = createUser(1, 'player1');
+      const player2 = createUser(2, 'player2');
+      game.player1 = player1;
+      game.player2 = player2;
+      game.state.winner = 'black';
+      const playerName = 'white';
+
+      // WHEN
+      const gameAndStatus = gameService.getGameAndStatus(game, playerName);
+
+      // THEN
+      expect(gameAndStatus.status).toEqual('ENDED');
+    });
   });
 });

--- a/web-app/src/games/games.service.spec.ts
+++ b/web-app/src/games/games.service.spec.ts
@@ -188,8 +188,7 @@ describe('GameService', () => {
   ⬡ ⬡ ⬡
        `),
       );
-      const player1 = createUser(1, 'player1');
-      game.player1 = player1;
+      game.player1 = createUser(1, 'player1');
       const playerName = 'white';
 
       // WHEN
@@ -208,10 +207,8 @@ describe('GameService', () => {
   ⬡ ⬡ ⬡
        `),
       );
-      const player1 = createUser(1, 'player1');
-      const player2 = createUser(2, 'player2');
-      game.player1 = player1;
-      game.player2 = player2;
+      game.player1 = createUser(1, 'player1');
+      game.player2 = createUser(2, 'player2');
       const playerName = 'white';
 
       // WHEN
@@ -230,10 +227,8 @@ describe('GameService', () => {
   ⬡ ⬡ ⬡
        `),
       );
-      const player1 = createUser(1, 'player1');
-      const player2 = createUser(2, 'player2');
-      game.player1 = player1;
-      game.player2 = player2;
+      game.player1 = createUser(1, 'player1');
+      game.player2 = createUser(2, 'player2');
       game.state.winner = 'black';
       const playerName = 'white';
 

--- a/web-app/src/games/games.service.ts
+++ b/web-app/src/games/games.service.ts
@@ -91,15 +91,16 @@ export class GamesService {
   }
 
   getGameAndStatus(game: Game, playerName: string): GameAndStatus {
+    const haveTwoPlayersJoinedIn = !!(game.player1 && game.player2);
     const gameAndStatus: GameAndStatus = {
       game: game,
-      readyToPlay: !!(game.player1 && game.player2),
+      readyToPlay: haveTwoPlayersJoinedIn,
       currentPlayerTurnToPlay:
         (game.state.turn === 'white' && playerName === game.player1.username) ||
         (game.state.turn === 'black' && playerName === game.player2.username),
       status: game.state.winner
         ? 'ENDED'
-        : !!(game.player1 && game.player2)
+        : haveTwoPlayersJoinedIn
         ? 'RUNNING'
         : 'INITIALIZED',
     };

--- a/web-app/src/games/games.service.ts
+++ b/web-app/src/games/games.service.ts
@@ -17,6 +17,7 @@ export interface GameAndStatus {
   game: Game;
   readyToPlay: boolean;
   currentPlayerTurnToPlay: boolean;
+  status: 'INITIALIZED' | 'RUNNING' | 'ENDED';
 }
 
 const configPathFromDistDir = '../../gameStateFile.json';
@@ -96,6 +97,11 @@ export class GamesService {
       currentPlayerTurnToPlay:
         (game.state.turn === 'white' && playerName === game.player1.username) ||
         (game.state.turn === 'black' && playerName === game.player2.username),
+      status: game.state.winner
+        ? 'ENDED'
+        : !!(game.player1 && game.player2)
+        ? 'RUNNING'
+        : 'INITIALIZED',
     };
     return gameAndStatus;
   }

--- a/web-app/src/users/user.entity.ts
+++ b/web-app/src/users/user.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Entity()
 export class User {
@@ -13,4 +19,10 @@ export class User {
 
   @Column({ nullable: true, select: false })
   lastSessionId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 }


### PR DESCRIPTION
## Description

- [x] Add a `createdAt` and `updatedAt` date to both entities `Game` and `User`
- [x] Add a status to the `GameAndStatus` interface, computed from the game state, that can have the following 3 values: `INITIALIZED`, `RUNNING` or `ENDED`

Related to : https://trello.com/c/HSUZcSyK/37-3-as-norbert-i-want-to-be-able-to-see-all-games-and-be-able-to-delete-some

## Demo
![hex-api-status](https://user-images.githubusercontent.com/14542336/156159138-a3348c43-9bfd-4d0d-ad1d-4e7438258b21.gif)

