### PR TITLE
Complete admin api find routes for games with search criteria and delete routes

### DIFF
--- a/web-app/src/games/api.admin.games.controller.ts
+++ b/web-app/src/games/api.admin.games.controller.ts
@@ -4,6 +4,8 @@ import {
   Param,
   UseGuards,
   NotFoundException,
+  Query,
+  Delete,
 } from '@nestjs/common';
 import { Game } from './game.entity';
 import { AuthGuard } from '@nestjs/passport';

--- a/web-app/src/games/api.admin.games.controller.ts
+++ b/web-app/src/games/api.admin.games.controller.ts
@@ -6,7 +6,15 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { Game } from './game.entity';
-import { ApiAdminGamesService } from './api.admin.games.service';
+import { AuthGuard } from '@nestjs/passport';
+import {
+  ApiAdminGamesService,
+  GamesSearchParams,
+} from './api.admin.games.service';
+import {
+  GamesSearchParamsPipe,
+  JsonNumberArrayPipe,
+} from './api.admin.games.pipes';
 
 @Controller('api/admin/games')
 export class ApiAdminGamesController {
@@ -20,7 +28,19 @@ export class ApiAdminGamesController {
   }
 
   @Get('')
-  async findMany(): Promise<Game[]> {
-    return this.gamesService.findMany();
+  async findMany(
+    @Query('s', GamesSearchParamsPipe) searchParams?: GamesSearchParams,
+  ): Promise<Game[]> {
+    return this.gamesService.findMany(searchParams);
+  }
+
+  @Delete(':id')
+  deleteOne(@Param('id') id: number) {
+    this.gamesService.deleteOne(id);
+  }
+
+  @Delete('')
+  deleteMany(@Query('ids', JsonNumberArrayPipe) ids: number[]) {
+    this.gamesService.deleteMany(ids);
   }
 }

--- a/web-app/src/games/api.admin.games.controller.ts
+++ b/web-app/src/games/api.admin.games.controller.ts
@@ -13,7 +13,7 @@ import {
   ApiAdminGamesService,
   GamesSearchParams,
 } from './api.admin.games.service';
-import { JsonPipe } from './api.admin.games.pipes';
+import { SimpleJsonParsePipe } from './api.admin.games.pipes';
 
 @Controller('api/admin/games')
 export class ApiAdminGamesController {
@@ -28,9 +28,9 @@ export class ApiAdminGamesController {
 
   @Get()
   async findMany(
-    @Query('s', new JsonPipe<GamesSearchParams>())
+    @Query('s', new SimpleJsonParsePipe<GamesSearchParams>())
     searchParams?: GamesSearchParams,
-  ): Promise<Game[]> {
+  ): Promise<{ data: Game[]; total: number }> {
     return this.gamesService.findMany(searchParams);
   }
 
@@ -40,7 +40,7 @@ export class ApiAdminGamesController {
   }
 
   @Delete()
-  deleteMany(@Query('ids', new JsonPipe<number[]>()) ids: number[]) {
+  deleteMany(@Query('ids', new SimpleJsonParsePipe<number[]>()) ids: number[]) {
     this.gamesService.deleteMany(ids);
   }
 }

--- a/web-app/src/games/api.admin.games.controller.ts
+++ b/web-app/src/games/api.admin.games.controller.ts
@@ -2,13 +2,11 @@ import {
   Controller,
   Get,
   Param,
-  UseGuards,
   NotFoundException,
   Query,
   Delete,
 } from '@nestjs/common';
 import { Game } from './game.entity';
-import { AuthGuard } from '@nestjs/passport';
 import {
   ApiAdminGamesService,
   GamesSearchParams,

--- a/web-app/src/games/api.admin.games.controller.ts
+++ b/web-app/src/games/api.admin.games.controller.ts
@@ -11,10 +11,7 @@ import {
   ApiAdminGamesService,
   GamesSearchParams,
 } from './api.admin.games.service';
-import {
-  GamesSearchParamsPipe,
-  JsonNumberArrayPipe,
-} from './api.admin.games.pipes';
+import { JsonPipe } from './api.admin.games.pipes';
 
 @Controller('api/admin/games')
 export class ApiAdminGamesController {
@@ -27,9 +24,10 @@ export class ApiAdminGamesController {
     return game;
   }
 
-  @Get('')
+  @Get()
   async findMany(
-    @Query('s', GamesSearchParamsPipe) searchParams?: GamesSearchParams,
+    @Query('s', new JsonPipe<GamesSearchParams>())
+    searchParams?: GamesSearchParams,
   ): Promise<Game[]> {
     return this.gamesService.findMany(searchParams);
   }
@@ -39,8 +37,8 @@ export class ApiAdminGamesController {
     this.gamesService.deleteOne(id);
   }
 
-  @Delete('')
-  deleteMany(@Query('ids', JsonNumberArrayPipe) ids: number[]) {
+  @Delete()
+  deleteMany(@Query('ids', new JsonPipe<number[]>()) ids: number[]) {
     this.gamesService.deleteMany(ids);
   }
 }

--- a/web-app/src/games/api.admin.games.pipes.ts
+++ b/web-app/src/games/api.admin.games.pipes.ts
@@ -1,7 +1,7 @@
 import { PipeTransform, Injectable, ArgumentMetadata } from '@nestjs/common';
 
 @Injectable()
-export class JsonPipe<T> implements PipeTransform<any, T> {
+export class SimpleJsonParsePipe<T> implements PipeTransform<any, T> {
   transform(value: any, _metadata: ArgumentMetadata): T | null {
     if (value) {
       return JSON.parse(value) as T;

--- a/web-app/src/games/api.admin.games.pipes.ts
+++ b/web-app/src/games/api.admin.games.pipes.ts
@@ -1,24 +1,10 @@
 import { PipeTransform, Injectable, ArgumentMetadata } from '@nestjs/common';
-import { GamesSearchParams } from './api.admin.games.service';
 
 @Injectable()
-export class GamesSearchParamsPipe
-  implements PipeTransform<any, GamesSearchParams>
-{
-  transform(value: any, _metadata: ArgumentMetadata): GamesSearchParams | null {
+export class JsonPipe<T> implements PipeTransform<any, T> {
+  transform(value: any, _metadata: ArgumentMetadata): T | null {
     if (value) {
-      return JSON.parse(value) as GamesSearchParams;
-    } else {
-      return null;
-    }
-  }
-}
-
-@Injectable()
-export class JsonNumberArrayPipe implements PipeTransform<any, number[]> {
-  transform(value: any, _metadata: ArgumentMetadata): number[] | null {
-    if (value) {
-      return JSON.parse(value) as number[];
+      return JSON.parse(value) as T;
     } else {
       return null;
     }

--- a/web-app/src/games/api.admin.games.pipes.ts
+++ b/web-app/src/games/api.admin.games.pipes.ts
@@ -1,0 +1,26 @@
+import { PipeTransform, Injectable, ArgumentMetadata } from '@nestjs/common';
+import { GamesSearchParams } from './api.admin.games.service';
+
+@Injectable()
+export class GamesSearchParamsPipe
+  implements PipeTransform<any, GamesSearchParams>
+{
+  transform(value: any, _metadata: ArgumentMetadata): GamesSearchParams | null {
+    if (value) {
+      return JSON.parse(value) as GamesSearchParams;
+    } else {
+      return null;
+    }
+  }
+}
+
+@Injectable()
+export class JsonNumberArrayPipe implements PipeTransform<any, number[]> {
+  transform(value: any, _metadata: ArgumentMetadata): number[] | null {
+    if (value) {
+      return JSON.parse(value) as number[];
+    } else {
+      return null;
+    }
+  }
+}

--- a/web-app/src/games/api.admin.games.service.spec.ts
+++ b/web-app/src/games/api.admin.games.service.spec.ts
@@ -1,0 +1,83 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Game } from './game.entity';
+import {
+  ApiAdminGamesService,
+  GamesFilter,
+  GamesSortColumn,
+} from './api.admin.games.service';
+
+let mockedGame: Game;
+
+const mockGamesRepository = {
+  findOne: (_id: number): Promise<Game> => {
+    return new Promise((resolve, _reject) => {
+      resolve(mockedGame);
+    });
+  },
+  save: (game: Game): Game => {
+    return game;
+  },
+  create: (game: Game): Game => {
+    return game;
+  },
+};
+
+describe('ApiAdminGameService', () => {
+  let gameService: ApiAdminGamesService;
+
+  beforeEach(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApiAdminGamesService,
+        {
+          provide: getRepositoryToken(Game),
+          useValue: mockGamesRepository,
+        },
+      ],
+    }).compile();
+
+    gameService = app.get<ApiAdminGamesService>(ApiAdminGamesService);
+  });
+
+  describe('file', () => {
+    it('should convert an array of sort columns to a typeorm order type"', () => {
+      const sort: GamesSortColumn[] = [
+        {
+          column: 'createdAt',
+          order: 'DESC',
+        },
+        {
+          column: 'id',
+          order: 'ASC',
+        },
+        {
+          column: 'player2',
+          order: 'DESC',
+        },
+      ];
+      expect(gameService.convertToFindOptionsOrder(sort)).toEqual({
+        createdAt: 'DESC',
+        id: 'ASC',
+        player2: 'DESC',
+      });
+    });
+
+    it('should convert an array of filters to a typeorm where type"', () => {
+      const filter: GamesFilter[] = [
+        {
+          column: 'player1',
+          value: 17,
+        },
+        {
+          column: 'status',
+          value: 'ENDED',
+        },
+      ];
+      expect(gameService.convertToFindOptionsWhere(filter)).toEqual({
+        player1: 17,
+        status: 'ENDED',
+      });
+    });
+  });
+});

--- a/web-app/src/games/api.admin.games.service.ts
+++ b/web-app/src/games/api.admin.games.service.ts
@@ -3,6 +3,31 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Game } from './game.entity';
 
+export type SortOrder = 'ASC' | 'DESC';
+
+export interface GamesSortColumn {
+  column: 'id' | 'player1' | 'player2' | 'createdAt' | 'updatedAt';
+  order: SortOrder;
+}
+
+export interface GamesFilter {
+  column: 'id' | 'player1' | 'player2' | 'status';
+  value: any;
+}
+
+export interface GamesSearchParams {
+  sort?: GamesSortColumn[];
+  filter?: GamesFilter[];
+  skip?: number;
+  take?: number;
+}
+
+type GameOrderType = {
+  [P in EntityFieldsNames<Game>]?: 'ASC' | 'DESC';
+};
+
+type GameWhereType = FindConditions<Game>;
+
 @Injectable()
 export class ApiAdminGamesService {
   constructor(
@@ -14,7 +39,74 @@ export class ApiAdminGamesService {
     return this.gamesRepository.findOne(id);
   }
 
-  findMany(): Promise<Game[]> {
-    return this.gamesRepository.find();
+  findMany(searchParams?: GamesSearchParams): Promise<Game[]> {
+    const findOptions: FindManyOptions<Game> = {};
+    if (searchParams) {
+      if (searchParams.sort) {
+        findOptions.order = this.convertToFindOptionsOrder(searchParams.sort);
+      }
+      if (searchParams.filter) {
+        findOptions.where = this.convertToFindOptionsWhere(searchParams.filter);
+      }
+      if (searchParams.skip) findOptions.skip = searchParams.skip;
+      if (searchParams.take) findOptions.take = searchParams.take;
+    }
+    return this.gamesRepository.find(findOptions);
+  }
+
+  deleteOne(id: number) {
+    return this.gamesRepository.delete(id);
+  }
+
+  deleteMany(ids: number[]) {
+    if (!ids) {
+      throw Error('A list of ids must be provided to delete games');
+    }
+    return this.gamesRepository.delete(ids);
+  }
+
+  convertToFindOptionsOrder(sort: GamesSortColumn[]): GameOrderType {
+    const order: GameOrderType = {};
+    sort.forEach((s) => {
+      switch (s.column) {
+        case 'createdAt':
+          order.createdAt = s.order;
+          break;
+        case 'updatedAt':
+          order.updatedAt = s.order;
+          break;
+        case 'id':
+          order.id = s.order;
+          break;
+        case 'player1':
+          order.player1 = s.order;
+          break;
+        case 'player2':
+          order.player2 = s.order;
+          break;
+      }
+    });
+    return order;
+  }
+
+  convertToFindOptionsWhere(filter: GamesFilter[]): GameWhereType {
+    const where: GameWhereType = {};
+    filter.forEach((f) => {
+      switch (f.column) {
+        case 'id':
+          where.id = f.value;
+          break;
+        case 'player1':
+          where.player1 = f.value;
+          break;
+        case 'player2':
+          where.player2 = f.value;
+          break;
+        case 'status':
+          where.status = f.value;
+          break;
+      }
+    });
+    return where;
   }
 }

--- a/web-app/src/games/api.admin.games.service.ts
+++ b/web-app/src/games/api.admin.games.service.ts
@@ -40,7 +40,9 @@ export class ApiAdminGamesService {
     return this.gamesRepository.findOne(id);
   }
 
-  findMany(searchParams?: GamesSearchParams): Promise<Game[]> {
+  async findMany(
+    searchParams?: GamesSearchParams,
+  ): Promise<{ data: Game[]; total: number }> {
     const findOptions: FindManyOptions<Game> = {};
     if (searchParams) {
       if (searchParams.sort) {
@@ -52,7 +54,13 @@ export class ApiAdminGamesService {
       if (searchParams.skip) findOptions.skip = searchParams.skip;
       if (searchParams.take) findOptions.take = searchParams.take;
     }
-    return this.gamesRepository.find(findOptions);
+    const [result, total] = await this.gamesRepository.findAndCount(
+      findOptions,
+    );
+    return {
+      data: result,
+      total,
+    };
   }
 
   deleteOne(id: number) {
@@ -60,51 +68,51 @@ export class ApiAdminGamesService {
   }
 
   deleteMany(ids: number[]) {
-    if (!ids) {
+    if (!ids || !ids.length) {
       throw Error('A list of ids must be provided to delete games');
     }
     return this.gamesRepository.delete(ids);
   }
 
-  convertToFindOptionsOrder(sort: GamesSortColumn[]): GameOrderType {
+  convertToFindOptionsOrder(sorts: GamesSortColumn[]): GameOrderType {
     const order: GameOrderType = {};
-    sort.forEach((s) => {
-      switch (s.column) {
+    sorts.forEach((sort) => {
+      switch (sort.column) {
         case 'createdAt':
-          order.createdAt = s.order;
+          order.createdAt = sort.order;
           break;
         case 'updatedAt':
-          order.updatedAt = s.order;
+          order.updatedAt = sort.order;
           break;
         case 'id':
-          order.id = s.order;
+          order.id = sort.order;
           break;
         case 'player1':
-          order.player1 = s.order;
+          order.player1 = sort.order;
           break;
         case 'player2':
-          order.player2 = s.order;
+          order.player2 = sort.order;
           break;
       }
     });
     return order;
   }
 
-  convertToFindOptionsWhere(filter: GamesFilter[]): GameWhereType {
+  convertToFindOptionsWhere(filters: GamesFilter[]): GameWhereType {
     const where: GameWhereType = {};
-    filter.forEach((f) => {
-      switch (f.column) {
+    filters.forEach((filter) => {
+      switch (filter.column) {
         case 'id':
-          where.id = f.value;
+          where.id = filter.value;
           break;
         case 'player1':
-          where.player1 = f.value;
+          where.player1 = filter.value;
           break;
         case 'player2':
-          where.player2 = f.value;
+          where.player2 = filter.value;
           break;
         case 'status':
-          where.status = f.value;
+          where.status = filter.value;
           break;
       }
     });

--- a/web-app/src/games/api.admin.games.service.ts
+++ b/web-app/src/games/api.admin.games.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { FindConditions, FindManyOptions, Repository } from 'typeorm';
+import { EntityFieldsNames } from 'typeorm/common/EntityFieldsNames';
 import { Game } from './game.entity';
 
 export type SortOrder = 'ASC' | 'DESC';

--- a/web-app/src/games/games.service.ts
+++ b/web-app/src/games/games.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { parseGameStateFromFile } from '../common/parseConfigFile';
 import { join } from 'path';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, ReturningStatementNotSupportedError } from 'typeorm';
+import { Repository } from 'typeorm';
 import { Game } from './game.entity';
 import {
   GameState,


### PR DESCRIPTION
## Content

- [x] Complete the `findMany()` implementation to handle search params
- [x] Complete the service with `deleteOne()` and `deleteMany()` implementations
- [x] Complete the controller
- [x] Cover the `convertToFindOptionsOrder()` and `convertToFindOptionsWhere()` functions with tests
- [x] Fix bug with `deleteMany()`, causing it to actually delete all games and not only the filtered ones
- [x] Add array support for filters (for bulk delete)

Relates to: https://trello.com/c/HSUZcSyK/37-3-as-norbert-i-want-to-be-able-to-see-all-games-and-be-able-to-delete-some

**Notes:** Any comments on the API contract (regarding the search params especially) are appreciated 🙂 

## Demo
![hex-api-admin-games](https://user-images.githubusercontent.com/14542336/156214859-8b656683-4828-43b7-b1da-74ef657d3f84.gif)

