### PR TITLE
Protect admin routes to be used by the admin user only

### DIFF
--- a/web-app/src/auth/auth.controller.ts
+++ b/web-app/src/auth/auth.controller.ts
@@ -21,7 +21,11 @@ export class AuthController {
     @Body() params: LoginData,
     @Request() req: { user: UserDataInjectedInRequestAfterAuth },
   ) {
-    return this.authService.getToken(req.user.id, req.user.username);
+    return this.authService.getToken(
+      req.user.id,
+      req.user.username,
+      req.user.admin,
+    );
   }
 
   @UseGuards(AuthGuard('jwt'))

--- a/web-app/src/auth/auth.service.ts
+++ b/web-app/src/auth/auth.service.ts
@@ -5,13 +5,13 @@ import { UsersService } from 'src/users/users.service';
 export interface UserDataInjectedInRequestAfterAuth {
   id: number;
   username: string;
-  admin?: boolean;
+  admin: boolean;
 }
 
 export interface JWTPayload {
   username: string;
   sub: number;
-  admin?: boolean;
+  admin: boolean;
 }
 
 @Injectable()

--- a/web-app/src/auth/auth.service.ts
+++ b/web-app/src/auth/auth.service.ts
@@ -5,11 +5,13 @@ import { UsersService } from 'src/users/users.service';
 export interface UserDataInjectedInRequestAfterAuth {
   id: number;
   username: string;
+  admin?: boolean;
 }
 
 export interface JWTPayload {
   username: string;
   sub: number;
+  admin?: boolean;
 }
 
 @Injectable()
@@ -26,7 +28,7 @@ export class AuthService {
     const user = await this.usersService.login(username, pass);
     if (user) {
       const { password, lastSessionId, ...result } = user;
-      return result;
+      return { ...result, admin: user.username === 'admin' };
     }
     return null;
   }
@@ -34,8 +36,9 @@ export class AuthService {
   async getToken(
     userId: number,
     username: string,
+    admin?: boolean,
   ): Promise<{ access_token: string }> {
-    const payload: JWTPayload = { username: username, sub: userId };
+    const payload: JWTPayload = { username: username, sub: userId, admin };
     return {
       access_token: this.jwtService.sign(payload),
     };

--- a/web-app/src/auth/jwt.strategy.ts
+++ b/web-app/src/auth/jwt.strategy.ts
@@ -17,6 +17,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(
     payload: JWTPayload,
   ): Promise<UserDataInjectedInRequestAfterAuth> {
-    return { id: payload.sub, username: payload.username };
+    return {
+      id: payload.sub,
+      username: payload.username,
+      admin: payload.admin,
+    };
   }
 }

--- a/web-app/src/auth/roles.decorator.ts
+++ b/web-app/src/auth/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const Roles = (...roles: string[]) => SetMetadata('roles', roles);

--- a/web-app/src/auth/roles.guard.ts
+++ b/web-app/src/auth/roles.guard.ts
@@ -1,0 +1,31 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserDataInjectedInRequestAfterAuth } from './auth.service';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const roles = this.reflector.get<string[]>('roles', context.getHandler());
+    if (!roles) {
+      return true;
+    }
+    const request = context.switchToHttp().getRequest();
+    const user: UserDataInjectedInRequestAfterAuth = request.user;
+    return matchRoles(roles, user);
+  }
+}
+
+function matchRoles(
+  roles: string[],
+  user: UserDataInjectedInRequestAfterAuth,
+): boolean {
+  if (!user) {
+    return false;
+  }
+  if (roles.includes('admin')) {
+    return !!user.admin;
+  }
+  return true;
+}

--- a/web-app/src/games/api.admin.games.controller.ts
+++ b/web-app/src/games/api.admin.games.controller.ts
@@ -1,22 +1,28 @@
 import {
   Controller,
-  Get,
-  Param,
-  NotFoundException,
-  Query,
   Delete,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+  UseGuards,
 } from '@nestjs/common';
-import { Game } from './game.entity';
+import { AuthGuard } from '@nestjs/passport';
+import { Roles } from 'src/auth/roles.decorator';
+import { RolesGuard } from 'src/auth/roles.guard';
+import { SimpleJsonParsePipe } from './api.admin.games.pipes';
 import {
   ApiAdminGamesService,
   GamesSearchParams,
 } from './api.admin.games.service';
-import { SimpleJsonParsePipe } from './api.admin.games.pipes';
+import { Game } from './game.entity';
 
+@UseGuards(AuthGuard('jwt'), RolesGuard)
 @Controller('api/admin/games')
 export class ApiAdminGamesController {
   constructor(private readonly gamesService: ApiAdminGamesService) {}
 
+  @Roles('admin')
   @Get(':id')
   async findOne(@Param('id') id: number): Promise<Game> {
     const game = await this.gamesService.findOne(id);
@@ -24,6 +30,7 @@ export class ApiAdminGamesController {
     return game;
   }
 
+  @Roles('admin')
   @Get()
   async findMany(
     @Query('s', new SimpleJsonParsePipe<GamesSearchParams>())
@@ -32,11 +39,13 @@ export class ApiAdminGamesController {
     return this.gamesService.findMany(searchParams);
   }
 
+  @Roles('admin')
   @Delete(':id')
   deleteOne(@Param('id') id: number) {
     this.gamesService.deleteOne(id);
   }
 
+  @Roles('admin')
   @Delete()
   deleteMany(@Query('ids', new SimpleJsonParsePipe<number[]>()) ids: number[]) {
     this.gamesService.deleteMany(ids);

--- a/web-app/src/users/users.service.ts
+++ b/web-app/src/users/users.service.ts
@@ -23,8 +23,10 @@ export class UsersService {
   async login(username: string, password: string): Promise<User | undefined> {
     const user = await this.usersRepository.findOne({
       where: { username: username },
+      select: ['id', 'username', 'password'],
     });
-    return compare(password, user.password) ? user : undefined;
+    if (!user) return undefined;
+    return (await compare(password, user.password)) ? user : undefined;
   }
 
   async create(


### PR DESCRIPTION
## Content

- [x] Fix login password check (https://github.com/marmelab/Hex/issues/54)
- [x] Add 'admin' role on admin api routes
- [x] Implement a RoleGuard
- [x] Store boolean to know if user is admin in JWT payload

Relates to: https://trello.com/c/XFCKJmht/39-05-as-norbert-i-want-to-be-the-only-person-able-to-access-the-administration-panel