### PR TITLE
Add login page to React Admin and send Credentials to the API

### DIFF
--- a/admin-app/.env.dist
+++ b/admin-app/.env.dist
@@ -1,1 +1,1 @@
-VITE_HEX_ADMIN_API_URL=http://localhost:3000/api/admin
+VITE_HEX_ADMIN_API_URL=http://localhost:3000/api

--- a/admin-app/src/App.tsx
+++ b/admin-app/src/App.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { Admin, Resource } from 'react-admin';
+import authProvider from './auth-provider';
 import { GameList } from './components/GameList';
 import dataProvider from './data-provider';
 
 const App = () => (
-  <Admin dataProvider={dataProvider}>
+  <Admin dataProvider={dataProvider} authProvider={authProvider}>
     <Resource name="games" list={GameList} />
   </Admin>
 );

--- a/admin-app/src/auth-provider.ts
+++ b/admin-app/src/auth-provider.ts
@@ -1,0 +1,38 @@
+import { AuthProvider, fetchUtils } from 'react-admin';
+
+const apiUrl = 'https://d1iqp7uyjrmy2a.cloudfront.net/api'; // FIXME
+const httpClient = fetchUtils.fetchJson;
+
+const authProvider: AuthProvider = {
+  login: function (params: any): Promise<any> {
+    const reqParams = {
+      method: 'POST',
+      body: JSON.stringify({
+        username: params.username,
+        password: params.password,
+      }),
+    };
+    return httpClient(`${apiUrl}/auth/login`, reqParams).then(({ json }) => {
+      localStorage.setItem('jwt', json.access_token);
+    });
+  },
+  logout: function (params: any): Promise<string | false | void> {
+    localStorage.removeItem('jwt');
+    return Promise.resolve();
+  },
+  checkAuth: function (params: any): Promise<void> {
+    return localStorage.getItem('jwt') ? Promise.resolve() : Promise.reject();
+  },
+  checkError: function (error: any): Promise<void> {
+    if (error.status === 401 || error.status === 403) {
+      localStorage.removeItem('jwt');
+      return Promise.reject();
+    }
+    return Promise.resolve();
+  },
+  getPermissions: function (params: any): Promise<any> {
+    return Promise.resolve();
+  },
+};
+
+export default authProvider;

--- a/admin-app/src/auth-provider.ts
+++ b/admin-app/src/auth-provider.ts
@@ -1,6 +1,6 @@
 import { AuthProvider, fetchUtils } from 'react-admin';
 
-const apiUrl = 'https://d1iqp7uyjrmy2a.cloudfront.net/api'; // FIXME
+const apiUrl = import.meta.env.VITE_HEX_ADMIN_API_URL;
 const httpClient = fetchUtils.fetchJson;
 
 const authProvider: AuthProvider = {

--- a/admin-app/src/auth-provider.ts
+++ b/admin-app/src/auth-provider.ts
@@ -4,7 +4,10 @@ const apiUrl = import.meta.env.VITE_HEX_ADMIN_API_URL;
 const httpClient = fetchUtils.fetchJson;
 
 const authProvider: AuthProvider = {
-  login: function (params: any): Promise<any> {
+  login: async function (params: {
+    username: string;
+    password: string;
+  }): Promise<void> {
     const reqParams = {
       method: 'POST',
       body: JSON.stringify({
@@ -12,25 +15,28 @@ const authProvider: AuthProvider = {
         password: params.password,
       }),
     };
-    return httpClient(`${apiUrl}/auth/login`, reqParams).then(({ json }) => {
-      localStorage.setItem('jwt', json.access_token);
-    });
+    const { json } = await httpClient(`${apiUrl}/auth/login`, reqParams);
+    localStorage.setItem('jwt', json.access_token);
   },
-  logout: function (params: any): Promise<string | false | void> {
+
+  logout: function (): Promise<void> {
     localStorage.removeItem('jwt');
     return Promise.resolve();
   },
-  checkAuth: function (params: any): Promise<void> {
+
+  checkAuth: function (): Promise<void> {
     return localStorage.getItem('jwt') ? Promise.resolve() : Promise.reject();
   },
-  checkError: function (error: any): Promise<void> {
+
+  checkError: function (error: { status: number }): Promise<void> {
     if (error.status === 401 || error.status === 403) {
       localStorage.removeItem('jwt');
       return Promise.reject();
     }
     return Promise.resolve();
   },
-  getPermissions: function (params: any): Promise<any> {
+
+  getPermissions: function (): Promise<any> {
     return Promise.resolve();
   },
 };

--- a/admin-app/src/data-provider.ts
+++ b/admin-app/src/data-provider.ts
@@ -1,12 +1,21 @@
-import { fetchUtils } from 'react-admin';
+import { fetchUtils, Options } from 'react-admin';
 
 const apiUrl = import.meta.env.VITE_HEX_ADMIN_API_URL;
-const httpClient = fetchUtils.fetchJson;
+
+const httpClient = (url: string, options: Options = {}) => {
+  if (!options.headers) {
+    options.headers = new Headers({ Accept: 'application/json' });
+  }
+  const jwt = localStorage.getItem('jwt');
+  if (jwt) {
+    options.headers.set('Authorization', `Bearer ${jwt}`);
+  }
+  return fetchUtils.fetchJson(url, options);
+};
 
 export default {
   getList: (resource: string) => {
     const url = `${apiUrl}/${resource}/`;
-
     return httpClient(url).then(({ json }) => ({
       data: json,
       total: json.length,

--- a/admin-app/src/data-provider.ts
+++ b/admin-app/src/data-provider.ts
@@ -1,6 +1,6 @@
 import { fetchUtils, Options } from 'react-admin';
 
-const apiUrl = `${import.meta.env.VITE_HEX_ADMIN_API_URL}/admin`;
+const adminApiUrl = `${import.meta.env.VITE_HEX_ADMIN_API_URL}/admin`;
 
 const httpClient = (url: string, options: Options = {}) => {
   if (!options.headers) {
@@ -15,10 +15,10 @@ const httpClient = (url: string, options: Options = {}) => {
 
 export default {
   getList: (resource: string) => {
-    const url = `${apiUrl}/${resource}/`;
+    const url = `${adminApiUrl}/${resource}/`;
     return httpClient(url).then(({ json }) => ({
-      data: json,
-      total: json.length,
+      data: json.data,
+      total: json.total,
     }));
   },
 

--- a/admin-app/src/data-provider.ts
+++ b/admin-app/src/data-provider.ts
@@ -1,6 +1,6 @@
 import { fetchUtils, Options } from 'react-admin';
 
-const apiUrl = import.meta.env.VITE_HEX_ADMIN_API_URL;
+const apiUrl = `${import.meta.env.VITE_HEX_ADMIN_API_URL}/admin`;
 
 const httpClient = (url: string, options: Options = {}) => {
   if (!options.headers) {


### PR DESCRIPTION
## Content

- [x] Add auth provider
- [x] Use jwt token in data-provider
- [x] Change variabilized API URL to be able to fetch /api/login (or expose a route on /api/admin/login)
- [x] Remember to change Github's secret to reflect changes made to the `.env` file

Relates to: https://trello.com/c/XFCKJmht/39-05-as-norbert-i-want-to-be-the-only-person-able-to-access-the-administration-panel