### PR TITLE
Fix the generation of a sessionid behind proxy

### DIFF
--- a/.github/workflows/deploy-web-app-ec2.yml
+++ b/.github/workflows/deploy-web-app-ec2.yml
@@ -2,24 +2,24 @@ name: Web app EC2 deployment
 on:
   push:
     branches:
-    - main
+      - fix-sessionid-behind-proxy
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: Staging AWS
-    
+
     steps:
-      - uses: actions/checkout@v2 
+      - uses: actions/checkout@v2
 
       - name: Deploy in EC2
         env:
-            PRIVATE_KEY: ${{ secrets.AWS_EC2_PRIVATE_KEY }}
-            HOSTNAME : ${{ secrets.AWS_EC2_PUBLIC_IP }}
-            USERNAME : ${{ secrets.AWS_EC2_USERNAME }}
-            WEBAPP_ENV_VARS: ${{ secrets.WEBAPP_ENV_VARS }}
-            POSTGRES_ENV_VARS: ${{ secrets.POSTGRES_ENV_VARS }}
-            
+          PRIVATE_KEY: ${{ secrets.AWS_EC2_PRIVATE_KEY }}
+          HOSTNAME: ${{ secrets.AWS_EC2_PUBLIC_IP }}
+          USERNAME: ${{ secrets.AWS_EC2_USERNAME }}
+          WEBAPP_ENV_VARS: ${{ secrets.WEBAPP_ENV_VARS }}
+          POSTGRES_ENV_VARS: ${{ secrets.POSTGRES_ENV_VARS }}
+
         run: |
           echo "$PRIVATE_KEY" > private_key && chmod 600 private_key
           echo "$WEBAPP_ENV_VARS" > ./web-app/.env

--- a/web-app/src/main.ts
+++ b/web-app/src/main.ts
@@ -11,6 +11,7 @@ async function bootstrap() {
   app.setBaseViewsDir(join(__dirname, '..', 'views'));
   app.setViewEngine('hbs');
   registerHandlebarsHelpers();
+  app.set('trust proxy', 1);
   app.use(
     session({
       secret: 'my-secret',


### PR DESCRIPTION
- [ ] Make nestjs generate sessionid based on X-Forwarded-For instead of the caller ip address(behind a cloudfront it's alway the cloudfront ip used to generate the session id)