### PR TITLE
Calculate winning path cost for a given board state

### DIFF
--- a/web-app/src/common/graphWinPrediction.ts
+++ b/web-app/src/common/graphWinPrediction.ts
@@ -75,13 +75,19 @@ function createPlayableCellEdges(
           { y: y - 1, x: x + 1 }, { y: y + 1, x: x - 1 },
         ];
         directNeighborCells.forEach(neighbor => {
-          if (!doesCellExist(gameState, neighbor) || doesCellExistAndHaveStone(gameState, neighbor, stoneColor === "black" ? "white" : "black")) return;
-          const cost = doesCellExistAndHaveStone(gameState, neighbor, stoneColor) ? LOW_EDGE_COST : HIGH_EDGE_COST;
-          addEdgeWithCost(hexBoardWinPredictionGraph, `${currentCell.y}-${currentCell.x}`, `${neighbor.y}-${neighbor.x}`, cost);
+          if (doesCellCouldBeOnVictoryPath(gameState, stoneColor, neighbor)) {
+            const cost = doesCellExistAndHaveStone(gameState, neighbor, stoneColor) ? LOW_EDGE_COST : HIGH_EDGE_COST;
+            addEdgeWithCost(hexBoardWinPredictionGraph, `${currentCell.y}-${currentCell.x}`, `${neighbor.y}-${neighbor.x}`, cost);
+          }
         })
       }
     })
   });
+}
+
+function doesCellCouldBeOnVictoryPath(gameState: GameState, stoneColor: StoneColor, coordinates: Coordinates) {
+  const opponentColor = stoneColor === "black" ? "white" : "black";
+  return (!doesCellExist(gameState, coordinates) || doesCellExistAndHaveStone(gameState, coordinates, opponentColor)) ? false : true;
 }
 
 /**

--- a/web-app/src/common/graphWinPrediction.ts
+++ b/web-app/src/common/graphWinPrediction.ts
@@ -1,0 +1,125 @@
+import * as jkstra from 'jkstra';
+import {
+  doesCellExist, doesCellExistAndHaveStone, GameState, StoneColor,
+  BLACK_NODE_START, BLACK_NODE_END, WHITE_NODE_START, WHITE_NODE_END
+} from './gameState';
+import { Coordinates } from './utils';
+
+export const UNDEFINED_EDGE_COST = -1;
+export const LOW_EDGE_COST = 1;
+export const HIGH_EDGE_COST = 100;
+
+export interface HexBoardWinPredictionGraph {
+  winPrediction: jkstra.Graph;
+  vertexMap: Map<string, jkstra.Vertex>;
+}
+
+/**
+ * Create a graph to represent the winnable paths of a given board.
+ * It doesn't add vertex/edges for the cells of the opposite color because it's not needed for this calculation.
+ */
+export function createWinPredictionGraph(
+  gameState: GameState,
+  stoneColor: StoneColor,
+): HexBoardWinPredictionGraph {
+  const hexBoardWinPredictionGraph: HexBoardWinPredictionGraph = {
+    winPrediction: new jkstra.Graph(),
+    vertexMap: new Map<string, jkstra.Vertex>(),
+  };
+  createVertices(gameState, hexBoardWinPredictionGraph, stoneColor);
+  createStartEndEdges(gameState, hexBoardWinPredictionGraph, stoneColor);
+  createPlayableCellEdges(gameState, hexBoardWinPredictionGraph, stoneColor);
+  return hexBoardWinPredictionGraph;
+}
+
+function createVertices(
+  gameState: GameState,
+  hexBoardWinPredictionGraph: HexBoardWinPredictionGraph,
+  stoneColor: StoneColor
+) {
+  if (stoneColor === "black") {
+    addVertex(hexBoardWinPredictionGraph, BLACK_NODE_START);
+    addVertex(hexBoardWinPredictionGraph, BLACK_NODE_END);
+  }
+  else {
+    addVertex(hexBoardWinPredictionGraph, WHITE_NODE_START);
+    addVertex(hexBoardWinPredictionGraph, WHITE_NODE_END);
+  }
+
+  // Add node for each cell on the board that's are not of the opposite color
+  gameState.board.forEach((row, y) => {
+    row.forEach((_cell, x) => {
+      if (_cell.value === stoneColor || _cell.value === "empty") {
+        addVertex(hexBoardWinPredictionGraph, `${y}-${x}`);
+      }
+    });
+  });
+}
+
+function addVertex(hexBoardWinPredictionGraph: HexBoardWinPredictionGraph, id: string) {
+  hexBoardWinPredictionGraph.vertexMap.set(id, hexBoardWinPredictionGraph.winPrediction.addVertex(id));
+}
+
+function createPlayableCellEdges(
+  gameState: GameState,
+  hexBoardWinPredictionGraph: HexBoardWinPredictionGraph,
+  stoneColor: StoneColor,
+) {
+  gameState.board.forEach((row, y) => {
+    row.forEach((cell, x) => {
+      if (cell.value == stoneColor || cell.value == "empty") {
+        const currentCell: Coordinates = { y: y, x: x };
+        const directNeighborCells = [
+          { y: y, x: x - 1 }, { y: y, x: x + 1 },
+          { y: y - 1, x: x }, { y: y + 1, x: x },
+          { y: y - 1, x: x - 1 }, { y: y + 1, x: x + 1 },
+        ];
+        directNeighborCells.forEach(neighbor => {
+          if (!doesCellExist(gameState, neighbor) || doesCellExistAndHaveStone(gameState, neighbor, stoneColor === "black" ? "white" : "black")) return;
+          const cost = doesCellExistAndHaveStone(gameState, neighbor, stoneColor) ? LOW_EDGE_COST : HIGH_EDGE_COST;
+          addEdgeWithCost(hexBoardWinPredictionGraph, `${currentCell.y}-${currentCell.x}`, `${neighbor.y}-${neighbor.x}`, cost);
+        })
+      }
+    })
+  });
+}
+
+/**
+ * Create edges for start and end nodes of the given color.
+ * White color borders are top-bottom and black color border are left-right.
+ */
+function createStartEndEdges(
+  gameState: GameState,
+  hexBoardWinPredictionGraph: HexBoardWinPredictionGraph,
+  stoneColor: StoneColor,
+) {
+  gameState.board.forEach((_, i) => {
+    if (stoneColor === "black") {
+      addEdgeWithCost(hexBoardWinPredictionGraph, `${i}-${gameState.board.length - 1}`, BLACK_NODE_END, UNDEFINED_EDGE_COST);
+      const currentFirstColumnCellValue = gameState.board[i][0].value;
+      if (currentFirstColumnCellValue !== "white") {
+        addEdgeWithCost(hexBoardWinPredictionGraph, BLACK_NODE_START, `${i}-0`, currentFirstColumnCellValue === "black" ? LOW_EDGE_COST : HIGH_EDGE_COST);
+      }
+    }
+    else {
+      addEdgeWithCost(hexBoardWinPredictionGraph, `${gameState.board.length - 1}-${i}`, WHITE_NODE_END, UNDEFINED_EDGE_COST);
+      const currentFirstRowCellValue = gameState.board[0][i].value;
+      if (currentFirstRowCellValue !== "black") {
+        addEdgeWithCost(hexBoardWinPredictionGraph, WHITE_NODE_START, `0-${i}`, currentFirstRowCellValue === "white" ? LOW_EDGE_COST : HIGH_EDGE_COST);
+      }
+    }
+  });
+}
+
+function addEdgeWithCost(
+  hexBoardWinPredictionGraph: HexBoardWinPredictionGraph,
+  vertex1: string,
+  vertex2: string,
+  cost: number,
+) {
+  hexBoardWinPredictionGraph.winPrediction.addEdge(
+    hexBoardWinPredictionGraph.vertexMap.get(vertex1),
+    hexBoardWinPredictionGraph.vertexMap.get(vertex2),
+    cost,
+  );
+}

--- a/web-app/src/common/graphWinPrediction.ts
+++ b/web-app/src/common/graphWinPrediction.ts
@@ -46,7 +46,7 @@ function createVertices(
     addVertex(hexBoardWinPredictionGraph, WHITE_NODE_END);
   }
 
-  // Add node for each cell on the board that's are not of the opposite color
+  // Add vertex for each cell on the board that's are not of the opposite color
   gameState.board.forEach((row, y) => {
     row.forEach((_cell, x) => {
       if (_cell.value === stoneColor || _cell.value === "empty") {
@@ -95,17 +95,23 @@ function createStartEndEdges(
 ) {
   gameState.board.forEach((_, i) => {
     if (stoneColor === "black") {
-      addEdgeWithCost(hexBoardWinPredictionGraph, `${i}-${gameState.board.length - 1}`, BLACK_NODE_END, UNDEFINED_EDGE_COST);
       const currentFirstColumnCellValue = gameState.board[i][0].value;
       if (currentFirstColumnCellValue !== "white") {
         addEdgeWithCost(hexBoardWinPredictionGraph, BLACK_NODE_START, `${i}-0`, currentFirstColumnCellValue === "black" ? LOW_EDGE_COST : HIGH_EDGE_COST);
       }
+      const currentLastColumnCellValue = gameState.board[i][gameState.board.length - 1].value;
+      if (currentLastColumnCellValue !== "white") {
+        addEdgeWithCost(hexBoardWinPredictionGraph, `${i}-${gameState.board.length - 1}`, BLACK_NODE_END, UNDEFINED_EDGE_COST);
+      }
     }
     else {
-      addEdgeWithCost(hexBoardWinPredictionGraph, `${gameState.board.length - 1}-${i}`, WHITE_NODE_END, UNDEFINED_EDGE_COST);
       const currentFirstRowCellValue = gameState.board[0][i].value;
       if (currentFirstRowCellValue !== "black") {
         addEdgeWithCost(hexBoardWinPredictionGraph, WHITE_NODE_START, `0-${i}`, currentFirstRowCellValue === "white" ? LOW_EDGE_COST : HIGH_EDGE_COST);
+      }
+      const currentLastRowCellValue = gameState.board[gameState.board.length - 1][i].value;
+      if (currentLastRowCellValue !== "black") {
+        addEdgeWithCost(hexBoardWinPredictionGraph, `${gameState.board.length - 1}-${i}`, WHITE_NODE_END, UNDEFINED_EDGE_COST);
       }
     }
   });

--- a/web-app/src/common/graphWinPrediction.ts
+++ b/web-app/src/common/graphWinPrediction.ts
@@ -72,7 +72,7 @@ function createPlayableCellEdges(
         const directNeighborCells = [
           { y: y, x: x - 1 }, { y: y, x: x + 1 },
           { y: y - 1, x: x }, { y: y + 1, x: x },
-          { y: y - 1, x: x - 1 }, { y: y + 1, x: x + 1 },
+          { y: y - 1, x: x + 1 }, { y: y + 1, x: x - 1 },
         ];
         directNeighborCells.forEach(neighbor => {
           if (!doesCellExist(gameState, neighbor) || doesCellExistAndHaveStone(gameState, neighbor, stoneColor === "black" ? "white" : "black")) return;

--- a/web-app/src/common/graphWinPrediction.ts
+++ b/web-app/src/common/graphWinPrediction.ts
@@ -75,7 +75,7 @@ function createPlayableCellEdges(
           { y: y - 1, x: x + 1 }, { y: y + 1, x: x - 1 },
         ];
         directNeighborCells.forEach(neighbor => {
-          if (doesCellCouldBeOnVictoryPath(gameState, stoneColor, neighbor)) {
+          if (canBePartOfAWiningPath(gameState, stoneColor, neighbor)) {
             const cost = doesCellExistAndHaveStone(gameState, neighbor, stoneColor) ? LOW_EDGE_COST : HIGH_EDGE_COST;
             addEdgeWithCost(hexBoardWinPredictionGraph, `${currentCell.y}-${currentCell.x}`, `${neighbor.y}-${neighbor.x}`, cost);
           }
@@ -85,7 +85,7 @@ function createPlayableCellEdges(
   });
 }
 
-function doesCellCouldBeOnVictoryPath(gameState: GameState, stoneColor: StoneColor, coordinates: Coordinates) {
+function canBePartOfAWiningPath(gameState: GameState, stoneColor: StoneColor, coordinates: Coordinates) {
   const opponentColor = stoneColor === "black" ? "white" : "black";
   return (!doesCellExist(gameState, coordinates) || doesCellExistAndHaveStone(gameState, coordinates, opponentColor)) ? false : true;
 }

--- a/web-app/src/common/graphWinPrediction.ts
+++ b/web-app/src/common/graphWinPrediction.ts
@@ -48,8 +48,8 @@ function createVertices(
 
   // Add vertex for each cell on the board that's are not of the opposite color
   gameState.board.forEach((row, y) => {
-    row.forEach((_cell, x) => {
-      if (_cell.value === stoneColor || _cell.value === "empty") {
+    row.forEach((cell, x) => {
+      if (cell.value === stoneColor || cell.value === "empty") {
         addVertex(hexBoardWinPredictionGraph, `${y}-${x}`);
       }
     });

--- a/web-app/src/common/pathfinding.spec.ts
+++ b/web-app/src/common/pathfinding.spec.ts
@@ -1,0 +1,131 @@
+import expect from 'expect';
+import { parseGameStateFromMultilineString } from './utils';
+import { getWinnablePathCost } from './pathfinding';
+
+describe('Shortest path cost', () => {
+  it('Get a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬡ ⬡ ⬡
+   ⬡ ⬡ ⬡
+    ⬢ ⬡ ⬡
+  `);
+
+    const cost = getWinnablePathCost(input, "black");
+
+    expect(cost).toStrictEqual(201);
+  });
+
+  it('Get a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬡ ⬡ ⬡
+   ⬡ ⬡ ⬡
+    ⬢ ⬢ ⬡
+  `);
+
+    const cost = getWinnablePathCost(input, "black");
+
+    expect(cost).toStrictEqual(102);
+  });
+
+  it('Get a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬡ ⬢ ⬢
+   ⬡ ⬡ ⬡
+    ⬡ ⬡ ⬢
+  `);
+
+    const cost = getWinnablePathCost(input, "black");
+
+    expect(cost).toStrictEqual(102);
+  });
+
+  it('Get a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬢ ⬡ ⬢
+   ⬡ ⬡ ⬡
+    ⬡ ⬡ ⬡
+  `);
+
+    const cost = getWinnablePathCost(input, "black");
+
+    expect(cost).toStrictEqual(102);
+  });
+
+  it('Get a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬢ ⬢ ⬡
+   ⬡ ⬡ ⬡
+    ⬡ ⬡ ⬡
+  `);
+
+    const cost = getWinnablePathCost(input, "black");
+
+    expect(cost).toStrictEqual(102);
+  });
+
+  it('Get a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬡ ⬡ ⬡
+   ⬡ ⬡ ⬡
+    ⬡ ⬡ ⬡
+  `);
+
+    const cost = getWinnablePathCost(input, "white");
+
+    expect(cost).toStrictEqual(300);
+  });
+
+  it('Get a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬢ ⬢ ⬢
+   ⬡ ⬡ ⬡
+    ⬡ ⬡ ⬡
+  `);
+
+    const cost = getWinnablePathCost(input, "black");
+
+    expect(cost).toStrictEqual(3);
+  });
+
+  it('Get a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  W ⬡ ⬡
+   ⬡ W ⬡
+    ⬡ ⬡ W
+  `);
+
+    const cost = getWinnablePathCost(input, "white");
+
+    expect(cost).toStrictEqual(3);
+  });
+
+  it('Get a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬢ ⬢ ⬢
+   ⬢ ⬢ ⬢
+    ⬢ ⬢ ⬢
+  `);
+
+    const cost = getWinnablePathCost(input, "black");
+
+    expect(cost).toStrictEqual(3);
+  });
+
+  it('Get a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬢ ⬢ ⬢ ⬢ ⬡ ⬡ ⬡ ⬡ ⬡
+   ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡ ⬡ ⬡
+    ⬡ ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡ ⬡
+     ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡
+      ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬢ ⬢
+       ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
+        ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
+         ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ 
+          ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
+  `);
+
+    const cost = getWinnablePathCost(input, "black");
+
+    expect(cost).toStrictEqual(9);
+  });
+});

--- a/web-app/src/common/pathfinding.spec.ts
+++ b/web-app/src/common/pathfinding.spec.ts
@@ -3,7 +3,7 @@ import { parseGameStateFromMultilineString } from './utils';
 import { getWinnablePathCost } from './pathfinding';
 
 describe('Shortest path cost', () => {
-  it('Get a valid winning path cost', () => {
+  it('Should return a valid winning path cost', () => {
     const input = parseGameStateFromMultilineString(`
   ⬡ ⬡ ⬡
    ⬡ ⬡ ⬡
@@ -15,7 +15,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(201);
   });
 
-  it('Get a valid winning path cost', () => {
+  it('Should return a valid winning path cost', () => {
     const input = parseGameStateFromMultilineString(`
   ⬡ ⬡ ⬡
    ⬡ ⬡ ⬡
@@ -27,7 +27,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(102);
   });
 
-  it('Get a valid winning path cost', () => {
+  it('Should return a valid winning path cost', () => {
     const input = parseGameStateFromMultilineString(`
   ⬡ ⬢ ⬢
    ⬡ ⬡ ⬡
@@ -39,7 +39,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(102);
   });
 
-  it('Get a valid winning path cost', () => {
+  it('Should return a valid winning path cost', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬡ ⬢
    ⬡ ⬡ ⬡
@@ -51,7 +51,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(102);
   });
 
-  it('Get a valid winning path cost', () => {
+  it('Should return a valid winning path cost', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬢ ⬡
    ⬡ ⬡ ⬡
@@ -63,7 +63,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(102);
   });
 
-  it('Get a valid winning path cost', () => {
+  it('Should return a valid winning path cost', () => {
     const input = parseGameStateFromMultilineString(`
   ⬡ ⬡ ⬡
    ⬡ ⬡ ⬡
@@ -75,7 +75,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(300);
   });
 
-  it('Get a valid winning path cost', () => {
+  it('Should return a valid winning path cost', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬢ ⬢
    ⬡ ⬡ ⬡
@@ -87,7 +87,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(3);
   });
 
-  it('Get a valid winning path cost', () => {
+  it('Should return a valid winning path cost', () => {
     const input = parseGameStateFromMultilineString(`
   W ⬡ ⬡
    ⬡ W ⬡
@@ -99,7 +99,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(3);
   });
 
-  it('Get a valid winning path cost', () => {
+  it('Should return a valid winning path cost', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬢ ⬢
    ⬢ ⬢ ⬢
@@ -111,7 +111,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(3);
   });
 
-  it('Get a valid winning path cost', () => {
+  it('Should return a valid winning path cost', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬢ ⬢ ⬢ ⬡ ⬡ ⬡ ⬡ ⬡
    ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡ ⬡ ⬡
@@ -127,5 +127,17 @@ describe('Shortest path cost', () => {
     const cost = getWinnablePathCost(input, "black");
 
     expect(cost).toStrictEqual(9);
+  });
+
+  it('Should return a negative winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬢ ⬢ ⬢
+   ⬢ ⬢ ⬢
+    ⬢ ⬢ ⬢
+  `);
+
+    const cost = getWinnablePathCost(input, "white");
+
+    expect(cost).toStrictEqual(-1);
   });
 });

--- a/web-app/src/common/pathfinding.spec.ts
+++ b/web-app/src/common/pathfinding.spec.ts
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import { parseGameStateFromMultilineString } from './utils';
-import { getWinnablePathCost } from './pathfinding';
+import { getNbMovesNeededToWin } from './pathfinding';
 
 describe('Shortest path cost', () => {
   it('Should return a valid winning path cost', () => {
@@ -10,9 +10,9 @@ describe('Shortest path cost', () => {
     ⬢ ⬡ ⬡
   `);
 
-    const cost = getWinnablePathCost(input, "black");
+    const cost = getNbMovesNeededToWin(input, "black");
 
-    expect(cost).toStrictEqual(201);
+    expect(cost).toStrictEqual(2);
   });
 
   it('Should return a valid winning path cost', () => {
@@ -22,9 +22,9 @@ describe('Shortest path cost', () => {
     ⬢ ⬢ ⬡
   `);
 
-    const cost = getWinnablePathCost(input, "black");
+    const cost = getNbMovesNeededToWin(input, "black");
 
-    expect(cost).toStrictEqual(102);
+    expect(cost).toStrictEqual(1);
   });
 
   it('Should return a valid winning path cost', () => {
@@ -34,9 +34,9 @@ describe('Shortest path cost', () => {
     ⬡ ⬡ ⬢
   `);
 
-    const cost = getWinnablePathCost(input, "black");
+    const cost = getNbMovesNeededToWin(input, "black");
 
-    expect(cost).toStrictEqual(102);
+    expect(cost).toStrictEqual(1);
   });
 
   it('Should return a valid winning path cost', () => {
@@ -46,9 +46,9 @@ describe('Shortest path cost', () => {
     ⬡ ⬡ ⬡
   `);
 
-    const cost = getWinnablePathCost(input, "black");
+    const cost = getNbMovesNeededToWin(input, "black");
 
-    expect(cost).toStrictEqual(102);
+    expect(cost).toStrictEqual(1);
   });
 
   it('Should return a valid winning path cost', () => {
@@ -58,9 +58,9 @@ describe('Shortest path cost', () => {
     ⬡ ⬡ ⬡
   `);
 
-    const cost = getWinnablePathCost(input, "black");
+    const cost = getNbMovesNeededToWin(input, "black");
 
-    expect(cost).toStrictEqual(102);
+    expect(cost).toStrictEqual(1);
   });
 
   it('Should return a valid winning path cost', () => {
@@ -70,9 +70,9 @@ describe('Shortest path cost', () => {
     ⬡ ⬡ ⬡
   `);
 
-    const cost = getWinnablePathCost(input, "white");
+    const cost = getNbMovesNeededToWin(input, "white");
 
-    expect(cost).toStrictEqual(300);
+    expect(cost).toStrictEqual(3);
   });
 
   it('Should return a valid winning path cost', () => {
@@ -82,9 +82,9 @@ describe('Shortest path cost', () => {
     ⬡ ⬡ ⬡
   `);
 
-    const cost = getWinnablePathCost(input, "black");
+    const cost = getNbMovesNeededToWin(input, "black");
 
-    expect(cost).toStrictEqual(3);
+    expect(cost).toStrictEqual(0);
   });
 
   it('Should return a valid winning path cost', () => {
@@ -94,9 +94,9 @@ describe('Shortest path cost', () => {
     ⬡ ⬡ W
   `);
 
-    const cost = getWinnablePathCost(input, "white");
+    const cost = getNbMovesNeededToWin(input, "white");
 
-    expect(cost).toStrictEqual(201);
+    expect(cost).toStrictEqual(2);
   });
 
   it('Should return a valid winning path cost', () => {
@@ -106,9 +106,9 @@ describe('Shortest path cost', () => {
     W ⬡ ⬡
   `);
 
-    const cost = getWinnablePathCost(input, 'white');
+    const cost = getNbMovesNeededToWin(input, 'white');
 
-    expect(cost).toStrictEqual(3);
+    expect(cost).toStrictEqual(0);
   });
 
   it('Should return a valid winning path cost', () => {
@@ -118,9 +118,9 @@ describe('Shortest path cost', () => {
     ⬢ ⬢ ⬢
   `);
 
-    const cost = getWinnablePathCost(input, "black");
+    const cost = getNbMovesNeededToWin(input, "black");
 
-    expect(cost).toStrictEqual(3);
+    expect(cost).toStrictEqual(0);
   });
 
   it('Should return a valid winning path cost', () => {
@@ -136,9 +136,9 @@ describe('Shortest path cost', () => {
           ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
   `);
 
-    const cost = getWinnablePathCost(input, "black");
+    const cost = getNbMovesNeededToWin(input, "black");
 
-    expect(cost).toStrictEqual(409);
+    expect(cost).toStrictEqual(4);
   });
 
   it('Should return a negative winning path cost', () => {
@@ -148,7 +148,7 @@ describe('Shortest path cost', () => {
     ⬢ ⬢ ⬢
   `);
 
-    const cost = getWinnablePathCost(input, "white");
+    const cost = getNbMovesNeededToWin(input, "white");
 
     expect(cost).toStrictEqual(-1);
   });

--- a/web-app/src/common/pathfinding.spec.ts
+++ b/web-app/src/common/pathfinding.spec.ts
@@ -96,6 +96,18 @@ describe('Shortest path cost', () => {
 
     const cost = getWinnablePathCost(input, "white");
 
+    expect(cost).toStrictEqual(201);
+  });
+
+  it('Should return a valid winning path cost', () => {
+    const input = parseGameStateFromMultilineString(`
+  ⬡ ⬡ W
+   ⬡ W ⬡
+    W ⬡ ⬡
+  `);
+
+    const cost = getWinnablePathCost(input, 'white');
+
     expect(cost).toStrictEqual(3);
   });
 
@@ -126,7 +138,7 @@ describe('Shortest path cost', () => {
 
     const cost = getWinnablePathCost(input, "black");
 
-    expect(cost).toStrictEqual(9);
+    expect(cost).toStrictEqual(409);
   });
 
   it('Should return a negative winning path cost', () => {

--- a/web-app/src/common/pathfinding.spec.ts
+++ b/web-app/src/common/pathfinding.spec.ts
@@ -3,7 +3,7 @@ import { parseGameStateFromMultilineString } from './utils';
 import { getNbMovesNeededToWin } from './pathfinding';
 
 describe('Shortest path cost', () => {
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 2', () => {
     const input = parseGameStateFromMultilineString(`
   ⬡ ⬡ ⬡
    ⬡ ⬡ ⬡
@@ -15,7 +15,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(2);
   });
 
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 1', () => {
     const input = parseGameStateFromMultilineString(`
   ⬡ ⬡ ⬡
    ⬡ ⬡ ⬡
@@ -27,7 +27,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(1);
   });
 
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 1', () => {
     const input = parseGameStateFromMultilineString(`
   ⬡ ⬢ ⬢
    ⬡ ⬡ ⬡
@@ -39,7 +39,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(1);
   });
 
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 1', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬡ ⬢
    ⬡ ⬡ ⬡
@@ -51,7 +51,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(1);
   });
 
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 1', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬢ ⬡
    ⬡ ⬡ ⬡
@@ -63,7 +63,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(1);
   });
 
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 3', () => {
     const input = parseGameStateFromMultilineString(`
   ⬡ ⬡ ⬡
    ⬡ ⬡ ⬡
@@ -75,7 +75,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(3);
   });
 
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 0', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬢ ⬢
    ⬡ ⬡ ⬡
@@ -87,7 +87,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(0);
   });
 
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 2', () => {
     const input = parseGameStateFromMultilineString(`
   W ⬡ ⬡
    ⬡ W ⬡
@@ -99,7 +99,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(2);
   });
 
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 0', () => {
     const input = parseGameStateFromMultilineString(`
   ⬡ ⬡ W
    ⬡ W ⬡
@@ -111,7 +111,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(0);
   });
 
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 0', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬢ ⬢
    ⬢ ⬢ ⬢
@@ -123,7 +123,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(0);
   });
 
-  it('Should return a valid winning path cost', () => {
+  it('Should return a winning path cost of 4', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬢ ⬢ ⬢ ⬡ ⬡ ⬡ ⬡ ⬡
    ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡ ⬡ ⬡
@@ -141,7 +141,7 @@ describe('Shortest path cost', () => {
     expect(cost).toStrictEqual(4);
   });
 
-  it('Should return a negative winning path cost', () => {
+  it('Should return a winning path cost of -1', () => {
     const input = parseGameStateFromMultilineString(`
   ⬢ ⬢ ⬢
    ⬢ ⬢ ⬢

--- a/web-app/src/common/pathfinding.ts
+++ b/web-app/src/common/pathfinding.ts
@@ -15,10 +15,10 @@ export function getWinningPathIfExist(
     hexBoardWinDetectionGraph.vertexMap.get(stoneColor === "black" ? BLACK_NODE_END : WHITE_NODE_END)
   );
   if (winningPath) {
-    const shortestPathWithoutStartNode = winningPath.slice(1);
+    const winningPathWithoutStartNode = winningPath.slice(1);
     return {
       hasWon: true,
-      winningPath: shortestPathWithoutStartNode.map((node) => {
+      winningPath: winningPathWithoutStartNode.map((node) => {
         return {
           x: parseInt(node.from.data.split('-')[1]),
           y: parseInt(node.from.data.split('-')[0]),
@@ -35,7 +35,7 @@ export function getNbMovesNeededToWin(
 ): number {
   const hexBoardWinPredictionGraph = createWinPredictionGraph(gameState, stoneColor);
   const dijkstra = new jkstra.algos.Dijkstra(hexBoardWinPredictionGraph.winPrediction);
-  let shortestPath = dijkstra.shortestPath(
+  const shortestPath = dijkstra.shortestPath(
     hexBoardWinPredictionGraph.vertexMap.get(stoneColor === "black" ? BLACK_NODE_START : WHITE_NODE_START),
     hexBoardWinPredictionGraph.vertexMap.get(stoneColor === "black" ? BLACK_NODE_END : WHITE_NODE_END),
     {

--- a/web-app/src/common/pathfinding.ts
+++ b/web-app/src/common/pathfinding.ts
@@ -1,7 +1,7 @@
 import * as jkstra from 'jkstra';
 import { BLACK_NODE_END, BLACK_NODE_START, GameState, StoneColor, WHITE_NODE_END, WHITE_NODE_START } from './gameState';
 import { createWinDetectionGraph } from './graphWinDetection';
-import { createWinPredictionGraph, UNDEFINED_EDGE_COST } from './graphWinPrediction';
+import { createWinPredictionGraph, HIGH_EDGE_COST, LOW_EDGE_COST, UNDEFINED_EDGE_COST } from './graphWinPrediction';
 import { Coordinates } from './utils';
 
 export function getWinningPathIfExist(
@@ -29,7 +29,7 @@ export function getWinningPathIfExist(
   return { hasWon: false, winningPath: null };
 }
 
-export function getWinnablePathCost(
+export function getNbMovesNeededToWin(
   gameState: GameState,
   stoneColor: StoneColor,
 ): number {
@@ -45,7 +45,18 @@ export function getWinnablePathCost(
     });
   if (!shortestPath) return -1;
   const cost = Object.keys(shortestPath).reduce(function (previous, key) {
-    return shortestPath[key].data === UNDEFINED_EDGE_COST ? previous : previous + shortestPath[key].data
+    return previous + mapEdgeCostToNbMoves(shortestPath[key].data)
   }, 0);
   return cost;
+}
+
+function mapEdgeCostToNbMoves(edgeCost: number) {
+  switch (edgeCost) {
+    case LOW_EDGE_COST:
+      return 0;
+    case HIGH_EDGE_COST:
+      return 1;
+    default:
+      return 0;
+  }
 }

--- a/web-app/src/common/pathfinding.ts
+++ b/web-app/src/common/pathfinding.ts
@@ -1,7 +1,7 @@
 import * as jkstra from 'jkstra';
 import { BLACK_NODE_END, BLACK_NODE_START, GameState, StoneColor, WHITE_NODE_END, WHITE_NODE_START } from './gameState';
 import { createWinDetectionGraph } from './graphWinDetection';
-import { HexBoardWinDetectionGraph } from './graphWinDetection';
+import { createWinPredictionGraph, UNDEFINED_EDGE_COST } from './graphWinPrediction';
 import { Coordinates } from './utils';
 
 export function getWinningPathIfExist(
@@ -27,4 +27,25 @@ export function getWinningPathIfExist(
     };
   }
   return { hasWon: false, winningPath: null };
+}
+
+export function getWinnablePathCost(
+  gameState: GameState,
+  stoneColor: StoneColor,
+): number {
+  const hexBoardWinPredictionGraph = createWinPredictionGraph(gameState, stoneColor);
+  const dijkstra = new jkstra.algos.Dijkstra(hexBoardWinPredictionGraph.winPrediction);
+  let shortestPath = dijkstra.shortestPath(
+    hexBoardWinPredictionGraph.vertexMap.get(stoneColor === "black" ? BLACK_NODE_START : WHITE_NODE_START),
+    hexBoardWinPredictionGraph.vertexMap.get(stoneColor === "black" ? BLACK_NODE_END : WHITE_NODE_END),
+    {
+      edgeCost: function (edge) {
+        return edge.data;
+      }
+    });
+  if (!shortestPath) return -1;
+  const cost = Object.keys(shortestPath).reduce(function (previous, key) {
+    return shortestPath[key].data === UNDEFINED_EDGE_COST ? previous : previous + shortestPath[key].data
+  }, 0);
+  return cost;
 }


### PR DESCRIPTION
- [x] Calculate the cost of the shortest path
- [x] Add edges for empty cells too
- [x] Use unidirictionnal edges instead of bidirectionnal edges and add a different cost for empty and cells of the targeted color
- [x] Test the calculation of the winning path cost
- [x] Wait for https://github.com/marmelab/Hex/pull/84 to be merged

Related to https://trello.com/c/0QadYH4a/30-1-as-norbert-given-a-game-state-i-want-a-better-advice-on-the-next-move