### PR TITLE
Improve next play advice based on the opponent score

### DIFF
--- a/web-app/src/common/prediction.spec.ts
+++ b/web-app/src/common/prediction.spec.ts
@@ -115,7 +115,7 @@ describe('Get a suggestion for the next play', () => {
     expect(() => getNextPlaySuggestion(input, "white")).toThrowError();
   });
 
-  it('Should get a suggestion to play on x:3,y:1 based on the two players', () => {
+  it('Should get a suggestion to play on x:3,y:1', () => {
     const input = parseGameStateFromMultilineString(`
     ⬡ ⬡ ⬡ ⬡ ⬡
      ⬡ ⬡ ⬡ ⬡ ⬡
@@ -127,5 +127,24 @@ describe('Get a suggestion for the next play', () => {
     const nextPlayAdvice = getNextPlaySuggestion(input, "white");
 
     expect(nextPlayAdvice).toStrictEqual({ x: 3, y: 1 });
+  });
+
+  it('Should get a suggestion to play on one from 3 possible coordinates', () => {
+    const input = parseGameStateFromMultilineString(`
+    ⬡ W ⬡ ⬡ ⬡
+     ⬡ ⬡ ⬡ E ⬢
+      W ⬡ ⬢ W ⬡
+       E ⬢ ⬡ W ⬡
+        E ⬡ ⬡ ⬡ ⬡
+    `);
+
+    const nextPlayAdvice = getNextPlaySuggestion(input, "black");
+
+    expect(areExpectedCoordinatesInList(nextPlayAdvice, [
+      { x: 3, y: 1 },
+      { x: 0, y: 3 },
+      { x: 0, y: 4 },
+    ])
+    ).toBeTruthy();
   });
 });

--- a/web-app/src/common/prediction.spec.ts
+++ b/web-app/src/common/prediction.spec.ts
@@ -16,7 +16,7 @@ describe('Should get an advice for the next play', () => {
 
     const nextPlayAdvice = getNextPlaySuggestion(input, "black");
 
-    expect(areCoordinatesEquals(nextPlayAdvice, { x: 2, y: 2 }) || areCoordinatesEquals(nextPlayAdvice, { x: 2, y: 1 })).toBeTruthy();
+    expect(areCoordinatesEquals(nextPlayAdvice, { x: 2, y: 1 }) || areCoordinatesEquals(nextPlayAdvice, { x: 2, y: 2 })).toBeTruthy();
   });
 
   it('Should get a good advice', () => {
@@ -82,14 +82,14 @@ describe('Should get an advice for the next play', () => {
 
   it('Should get a good advice', () => {
     const input = parseGameStateFromMultilineString(`
-  ⬡ ⬡ ⬡
+  W ⬡ ⬡
    ⬡ W ⬡
-    W ⬡ ⬡
+    ⬡ ⬡ ⬡
   `);
 
     const nextPlayAdvice = getNextPlaySuggestion(input, "white");
 
-    expect(nextPlayAdvice).toStrictEqual({ x: 2, y: 0 });
+    expect(areCoordinatesEquals(nextPlayAdvice, { x: 1, y: 2 }) || areCoordinatesEquals(nextPlayAdvice, { x: 2, y: 2 })).toBeTruthy();
   });
 
   it('Should get an obvious advice', () => {
@@ -116,19 +116,15 @@ describe('Should get an advice for the next play', () => {
 
   it('Should get a good advice related to the possibilities of the opponent', () => {
     const input = parseGameStateFromMultilineString(`
-    ⬢ ⬢ ⬢ ⬢ ⬡ ⬡ ⬡ ⬡ ⬡
-     ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡ ⬡ ⬡
-      ⬡ ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡ ⬡
-       ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡
-        ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬢ ⬢
-         ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
-          ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
-           ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ 
-            ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
+    ⬡ ⬡ ⬡ ⬡ ⬡
+     ⬡ ⬡ ⬡ ⬡ ⬡
+      ⬡ ⬡ ⬢ W ⬡
+       ⬡ ⬢ ⬡ W ⬡
+        ⬡ ⬡ ⬡ ⬡ ⬡
     `);
 
     const nextPlayAdvice = getNextPlaySuggestion(input, "white");
 
-    expect(nextPlayAdvice).toStrictEqual({ x: 1, y: 1 });
+    expect(nextPlayAdvice).toStrictEqual({ x: 3, y: 1 });
   });
 });

--- a/web-app/src/common/prediction.spec.ts
+++ b/web-app/src/common/prediction.spec.ts
@@ -101,4 +101,22 @@ describe('Should get an advice for the next play', () => {
 
     expect(() => getNextPlaySuggestion(input, "white")).toThrowError();
   });
+
+  it('Should get a good advice related to the possibilities of the opponent', () => {
+    const input = parseGameStateFromMultilineString(`
+    ⬢ ⬢ ⬢ ⬢ ⬡ ⬡ ⬡ ⬡ ⬡
+     ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡ ⬡ ⬡
+      ⬡ ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡ ⬡
+       ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬢ ⬡ ⬡
+        ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬢ ⬢
+         ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
+          ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
+           ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ 
+            ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡ ⬡
+    `);
+
+    const nextPlayAdvice = getNextPlaySuggestion(input, "white");
+
+    expect(nextPlayAdvice).toStrictEqual({ x: 1, y: 1 });
+  });
 });

--- a/web-app/src/common/prediction.spec.ts
+++ b/web-app/src/common/prediction.spec.ts
@@ -115,7 +115,7 @@ describe('Get a suggestion for the next play', () => {
     expect(() => getNextPlaySuggestion(input, "white")).toThrowError();
   });
 
-  it('Should get a good advice related to the possibilities of the opponent', () => {
+  it('Should get a suggestion to play on x:3,y:1 based on the two players', () => {
     const input = parseGameStateFromMultilineString(`
     ⬡ ⬡ ⬡ ⬡ ⬡
      ⬡ ⬡ ⬡ ⬡ ⬡

--- a/web-app/src/common/prediction.spec.ts
+++ b/web-app/src/common/prediction.spec.ts
@@ -132,10 +132,10 @@ describe('Get a suggestion for the next play', () => {
   it('Should get a suggestion to play on one from 3 possible coordinates', () => {
     const input = parseGameStateFromMultilineString(`
     ⬡ W ⬡ ⬡ ⬡
-     ⬡ ⬡ ⬡ E ⬢
+     ⬡ ⬡ ⬡ ⬡ ⬢
       W ⬡ ⬢ W ⬡
-       E ⬢ ⬡ W ⬡
-        E ⬡ ⬡ ⬡ ⬡
+       ⬡ ⬢ ⬡ W ⬡
+        ⬡ ⬡ ⬡ ⬡ ⬡
     `);
 
     const nextPlayAdvice = getNextPlaySuggestion(input, "black");

--- a/web-app/src/common/prediction.ts
+++ b/web-app/src/common/prediction.ts
@@ -2,26 +2,46 @@ import { GameState, StoneColor } from './gameState';
 import { Coordinates, deepCloneObject } from './utils';
 import { getNbMovesNeededToWin } from './pathfinding';
 
+interface PlayPrediction {
+  coordinates: Coordinates;
+  playerRemainingMovesToWin: number;
+  opponentRemainingMovesToWin: number;
+  score: number;
+}
+
 export function getNextPlaySuggestion(gameState: GameState, stoneColor: StoneColor): Coordinates {
-  const allPotentialPlays = [];
+  const playableCells = getPlayableCells(gameState);
+  if (playableCells.length === 0) throw new Error("There is no playable cell in the given board.")
+  const playPredictions = playableCells.map(coordinates =>
+    getPlayPrediction(gameState, coordinates, stoneColor)
+  );
+  return getBestPossiblePlay(playPredictions).coordinates;
+}
+
+function getPlayableCells(gameState: GameState): Coordinates[] {
+  const playableCells = [];
   gameState.board.forEach((row, y) => {
     row.forEach((cell, x) => {
       if (cell.value === "empty")
-        allPotentialPlays.push({ x, y })
+        playableCells.push({ x, y })
     })
   });
+  return playableCells;
+}
 
-  if (allPotentialPlays.length === 0) throw new Error("There is no playable cell in the given board.")
+function getPlayPrediction(gameState: GameState, coordinates: Coordinates, stoneColor: StoneColor): PlayPrediction {
+  const potentialGameState = deepCloneObject(gameState) as GameState;
+  potentialGameState.board[coordinates.y][coordinates.x].value = stoneColor;
+  const playerRemainingMovesToWin = getNbMovesNeededToWin(potentialGameState, stoneColor);
+  const opponentColor = stoneColor === "black" ? "white" : "black";
+  const opponentRemainingMovesToWin = getNbMovesNeededToWin(potentialGameState, opponentColor);
+  return { coordinates, playerRemainingMovesToWin, opponentRemainingMovesToWin, score: playerRemainingMovesToWin - opponentRemainingMovesToWin }
+}
 
-  const winCostForPotentialPlays = allPotentialPlays.map(playPosition => {
-    const potentialGameState = deepCloneObject(gameState) as GameState;
-    potentialGameState.board[playPosition.y][playPosition.x].value = stoneColor;
-    const opponentColor = stoneColor === "black" ? "white" : "black";
-    return { playPosition, myWinCost: getNbMovesNeededToWin(potentialGameState, stoneColor), myAdvWinCost: getNbMovesNeededToWin(potentialGameState, opponentColor), winCost: getNbMovesNeededToWin(potentialGameState, stoneColor) - getNbMovesNeededToWin(potentialGameState, opponentColor) }
+function getBestPossiblePlay(potentialPlays: PlayPrediction[]): PlayPrediction {
+  const winningPlays = potentialPlays.filter(play => play.playerRemainingMovesToWin === 0);
+  if (winningPlays.length > 0) return winningPlays[0];
+  return potentialPlays.reduce(function (prev, curr) {
+    return prev.score <= curr.score ? prev : curr;
   });
-
-  const winningPlays = winCostForPotentialPlays.filter(play => play.myWinCost === 0);
-  return winningPlays.length > 0 ? winningPlays[0].playPosition : winCostForPotentialPlays.reduce(function (prev, curr) {
-    return prev.winCost <= curr.winCost ? prev : curr;
-  }).playPosition;
 }

--- a/web-app/src/common/prediction.ts
+++ b/web-app/src/common/prediction.ts
@@ -10,16 +10,18 @@ export function getNextPlaySuggestion(gameState: GameState, stoneColor: StoneCol
         allPotentialPlays.push({ x, y })
     })
   });
+
   if (allPotentialPlays.length === 0) throw new Error("There is no playable cell in the given board.")
 
   const winCostForPotentialPlays = allPotentialPlays.map(playPosition => {
     const potentialGameState = deepCloneObject(gameState) as GameState;
     potentialGameState.board[playPosition.y][playPosition.x].value = stoneColor;
     const opponentColor = stoneColor === "black" ? "white" : "black";
-    return { playPosition, currentPlayerWinCost: getNbMovesNeededToWin(potentialGameState, stoneColor), opponentWinCost: getNbMovesNeededToWin(potentialGameState, opponentColor) }
+    return { playPosition, myWinCost: getNbMovesNeededToWin(potentialGameState, stoneColor), myAdvWinCost: getNbMovesNeededToWin(potentialGameState, opponentColor), winCost: getNbMovesNeededToWin(potentialGameState, stoneColor) - getNbMovesNeededToWin(potentialGameState, opponentColor) }
   });
 
-  return winCostForPotentialPlays.reduce(function (prev, curr) {
-    return (prev.currentPlayerWinCost - prev.opponentWinCost) < (curr.currentPlayerWinCost - prev.opponentWinCost) ? prev : curr;
+  const winningPlays = winCostForPotentialPlays.filter(play => play.myWinCost === 0);
+  return winningPlays.length > 0 ? winningPlays[0].playPosition : winCostForPotentialPlays.reduce(function (prev, curr) {
+    return prev.winCost < curr.winCost ? prev : curr;
   }).playPosition;
 }

--- a/web-app/src/common/prediction.ts
+++ b/web-app/src/common/prediction.ts
@@ -15,10 +15,11 @@ export function getNextPlaySuggestion(gameState: GameState, stoneColor: StoneCol
   const winCostForPotentialPlays = allPotentialPlays.map(playPosition => {
     const potentialGameState = deepCloneObject(gameState) as GameState;
     potentialGameState.board[playPosition.y][playPosition.x].value = stoneColor;
-    return { playPosition, cost: getWinnablePathCost(potentialGameState, stoneColor) }
+    const opponentColor = stoneColor === "black" ? "white" : "black";
+    return { playPosition, currentPlayerWinCost: getWinnablePathCost(potentialGameState, stoneColor), opponentWinCost: getWinnablePathCost(potentialGameState, opponentColor) }
   });
 
   return winCostForPotentialPlays.reduce(function (prev, curr) {
-    return prev.cost < curr.cost ? prev : curr;
+    return (prev.currentPlayerWinCost - prev.opponentWinCost) < (curr.currentPlayerWinCost - prev.opponentWinCost) ? prev : curr;
   }).playPosition;
 }


### PR DESCRIPTION
- [x] Find a metric to take the opponent into account for the suggested move
- [x] Update the func to suggest a move to use this new metric
- [x] Add more relevant tests
- [x] Wait for https://github.com/marmelab/Hex/pull/87 to be merged
- [x] ~Think about what to do when the next move is a winning move for the opponent(merge the code from the hint logic into this suggestion func ?)~ => Moved into the future work about the AI

Related to https://trello.com/c/fYq01Sfi/33-05-as-norbert-i-want-to-be-advised-on-what-best-move-i-should-play-next-considering-patricks-options

## Demo
![demo-play-suggestion-based-on-opponent-too](https://user-images.githubusercontent.com/99178555/157442039-98cb806c-1bc2-4cc5-9e93-a7f53d9d0a54.gif)